### PR TITLE
Properly reflect results in local timezone

### DIFF
--- a/app/analytics/query.test.ts
+++ b/app/analytics/query.test.ts
@@ -46,56 +46,62 @@ describe("AnalyticsEngineAPI", () => {
 
     describe("getViewsGroupedByInterval", () => {
         test("should return an array of [timestamp, count] tuples grouped by day", async () => {
+            expect(process.env.TZ).toBe("EST");
+
             fetch.mockResolvedValue(new Promise(resolve => {
                 resolve(createFetchResponse({
                     data: [
                         {
                             count: 3,
                             // note: intentionally sparse data (data for some timestamps missing)
-                            bucket: "2024-01-13 00:00:00",
+                            bucket: "2024-01-13 05:00:00",
                         },
                         {
                             count: 2,
-                            bucket: "2024-01-16 00:00:00"
+                            bucket: "2024-01-16 05:00:00"
                         },
                         {
                             count: 1,
-                            bucket: "2024-01-17 00:00:00"
+                            bucket: "2024-01-17 05:00:00"
                         }
                     ]
                 }))
             }));
 
-            vi.setSystemTime(new Date("2024-01-18T05:33:02").getTime());
+            vi.setSystemTime(new Date("2024-01-18T09:33:02").getTime());
 
             const result1 = await api.getViewsGroupedByInterval("example.com", "DAY", 7);
 
+            // results should all be at 05:00:00 because local timezone is UTC-5 --
+            // this set of results represents "start of day" in local tz, which is 5 AM UTC
             expect(result1).toEqual([
-                ["2024-01-11 00:00:00", 0],
-                ["2024-01-12 00:00:00", 0],
-                ["2024-01-13 00:00:00", 3],
-                ["2024-01-14 00:00:00", 0],
-                ["2024-01-15 00:00:00", 0],
-                ["2024-01-16 00:00:00", 2],
-                ["2024-01-17 00:00:00", 1],
-                ["2024-01-18 00:00:00", 0],
+                ["2024-01-11 05:00:00", 0],
+                ["2024-01-12 05:00:00", 0],
+                ["2024-01-13 05:00:00", 3],
+                ["2024-01-14 05:00:00", 0],
+                ["2024-01-15 05:00:00", 0],
+                ["2024-01-16 05:00:00", 2],
+                ["2024-01-17 05:00:00", 1],
+                ["2024-01-18 05:00:00", 0],
             ]);
 
             expect(await api.getViewsGroupedByInterval("example.com", "DAY", 5))
 
             const result2 = await api.getViewsGroupedByInterval("example.com", "DAY", 5);
             expect(result2).toEqual([
-                ["2024-01-13 00:00:00", 3],
-                ["2024-01-14 00:00:00", 0],
-                ["2024-01-15 00:00:00", 0],
-                ["2024-01-16 00:00:00", 2],
-                ["2024-01-17 00:00:00", 1],
-                ["2024-01-18 00:00:00", 0],
+                ["2024-01-13 05:00:00", 3],
+                ["2024-01-14 05:00:00", 0],
+                ["2024-01-15 05:00:00", 0],
+                ["2024-01-16 05:00:00", 2],
+                ["2024-01-17 05:00:00", 1],
+                ["2024-01-18 05:00:00", 0],
             ]);
         });
     });
 
     test("should return an array of [timestamp, count] tuples grouped by hour", async () => {
+        expect(process.env.TZ).toBe("EST");
+
         fetch.mockResolvedValue(new Promise(resolve => {
             resolve(createFetchResponse({
                 data: [
@@ -120,12 +126,10 @@ describe("AnalyticsEngineAPI", () => {
 
         const result1 = await api.getViewsGroupedByInterval("example.com", "HOUR", 1);
 
+        // reminder results are expressed as UTC
+        // so if we want the last 24 hours from 05:00:00 in local time (EST), the actual
+        // time range in UTC starts and ends at 10:00:00 (+5 hours)
         expect(result1).toEqual([
-            ['2024-01-17 05:00:00', 0],
-            ['2024-01-17 06:00:00', 0],
-            ['2024-01-17 07:00:00', 0],
-            ['2024-01-17 08:00:00', 0],
-            ['2024-01-17 09:00:00', 0],
             ['2024-01-17 10:00:00', 0],
             ['2024-01-17 11:00:00', 3],
             ['2024-01-17 12:00:00', 0],
@@ -145,7 +149,12 @@ describe("AnalyticsEngineAPI", () => {
             ['2024-01-18 02:00:00', 0],
             ['2024-01-18 03:00:00', 0],
             ['2024-01-18 04:00:00', 0],
-            ['2024-01-18 05:00:00', 0]
+            ['2024-01-18 05:00:00', 0],
+            ['2024-01-18 06:00:00', 0],
+            ['2024-01-18 07:00:00', 0],
+            ['2024-01-18 08:00:00', 0],
+            ['2024-01-18 09:00:00', 0],
+            ['2024-01-18 10:00:00', 0]
         ]);
     });
 

--- a/app/analytics/query.ts
+++ b/app/analytics/query.ts
@@ -139,8 +139,6 @@ export class AnalyticsEngineAPI {
     }
 
     async getViewsGroupedByInterval(siteId: string, intervalType: string, sinceDays: number, tz?: string): Promise<any> {
-        // defaults to 1 day if not specified
-        const interval = sinceDays || 1;
         const siteIdColumn = ColumnMappings['siteId'];
 
         let intervalCount = 1;

--- a/app/components/TimeSeriesChart.tsx
+++ b/app/components/TimeSeriesChart.tsx
@@ -1,10 +1,6 @@
 import PropTypes, { InferProps } from 'prop-types';
 
-import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, TooltipProps } from 'recharts';
-import {
-    ValueType,
-    NameType,
-} from 'recharts/types/component/DefaultTooltipContent';
+import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 
 export default function TimeSeriesChart({ data, intervalType }: InferProps<typeof TimeSeriesChart.propTypes>) {
     // chart doesn't really work no data points, so just bail out

--- a/app/components/TimeSeriesChart.tsx
+++ b/app/components/TimeSeriesChart.tsx
@@ -1,6 +1,10 @@
 import PropTypes, { InferProps } from 'prop-types';
 
-import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, TooltipProps } from 'recharts';
+import {
+    ValueType,
+    NameType,
+} from 'recharts/types/component/DefaultTooltipContent';
 
 export default function TimeSeriesChart({ data, intervalType }: InferProps<typeof TimeSeriesChart.propTypes>) {
     // chart doesn't really work no data points, so just bail out
@@ -11,8 +15,12 @@ export default function TimeSeriesChart({ data, intervalType }: InferProps<typeo
     // get the max integer value of data views
     const maxViews = Math.max(...data.map((item: any) => item.views));
 
-    function dateFormatter(date: string): string {
+    function xAxisDateFormatter(date: string): string {
+
         const dateObj = new Date(date);
+
+        // convert from utc to local time
+        dateObj.setMinutes(dateObj.getMinutes() - dateObj.getTimezoneOffset());
 
         switch (intervalType) {
             case 'DAY':
@@ -22,6 +30,16 @@ export default function TimeSeriesChart({ data, intervalType }: InferProps<typeo
             default:
                 throw new Error('Invalid interval type');
         }
+    }
+
+    function tooltipDateFormatter(date: string): string {
+
+        const dateObj = new Date(date);
+
+        // convert from utc to local time
+        dateObj.setMinutes(dateObj.getMinutes() - dateObj.getTimezoneOffset());
+
+        return dateObj.toLocaleString('en-us', { weekday: "short", month: "short", day: "numeric", hour: "numeric", minute: "numeric" });
     }
 
     return (
@@ -38,14 +56,14 @@ export default function TimeSeriesChart({ data, intervalType }: InferProps<typeo
                 }}
             >
                 <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="date" tickFormatter={dateFormatter} />
+                <XAxis dataKey="date" tickFormatter={xAxisDateFormatter} />
 
                 {/* manually setting maxViews vs using recharts "dataMax" key cause it doesnt seem to work */}
                 <YAxis dataKey="views" domain={[0, maxViews]} />
-                <Tooltip />
+                <Tooltip labelFormatter={tooltipDateFormatter} />
                 <Area dataKey="views" stroke="#F46A3D" strokeWidth="2" fill="#F99C35" />
             </AreaChart>
-        </ResponsiveContainer>
+        </ResponsiveContainer >
     );
 
 }

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -1,5 +1,3 @@
-import type { RequestInit } from "@cloudflare/workers-types";
-
 import { Card, CardContent } from "~/components/ui/card"
 import {
     Select,

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -1,3 +1,5 @@
+import type { RequestInit } from "@cloudflare/workers-types";
+
 import { Card, CardContent } from "~/components/ui/card"
 import {
     Select,
@@ -78,7 +80,9 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
             break;
     }
 
-    const viewsGroupedByInterval = analyticsEngine.getViewsGroupedByInterval(actualSiteId, intervalType, interval);
+    const tz = context.requestTimezone as string;
+
+    const viewsGroupedByInterval = analyticsEngine.getViewsGroupedByInterval(actualSiteId, intervalType, interval, tz);
 
     return json({
         siteId: siteId || '@unknown',

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "dev": "remix dev --manual -c \"npm start\"",
     "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
     "start": "wrangler dev ./build/index.js",
-    "test": "vitest run",
-    "test-ci": "vitest run --coverage",
+    "test": "TZ=EST vitest run",
+    "test-ci": "TZ=EST vitest run --coverage",
     "typecheck": "tsc",
     "prepare": "husky install"
   },

--- a/server.ts
+++ b/server.ts
@@ -1,3 +1,5 @@
+import type { RequestInit } from "@cloudflare/workers-types";
+
 import { getAssetFromKV } from "@cloudflare/kv-asset-handler";
 import type { AppLoadContext } from "@remix-run/cloudflare";
 import { createRequestHandler, logDevReady } from "@remix-run/cloudflare";
@@ -53,6 +55,7 @@ export default {
         try {
             const loadContext: AppLoadContext = {
                 env,
+                requestTimezone: (request as RequestInit).cf?.timezone as string
             };
             return await handleRemixRequest(request, loadContext);
         } catch (error) {


### PR DESCRIPTION
Fixes #6

- Local timezone is extracted from `cf` property and passed as context to loader
- Results by day now use local timezone to determine start of day
- Internally, dates are now consistently represented in UTC, but on display converted to local time (i.e. in chart)
- Tests now set timezone (via env variables) and incorporate timezone in results