### PR TITLE
When no site provided on query string, redirect w/ with valid site specified

### DIFF
--- a/app/analytics/query.test.ts
+++ b/app/analytics/query.test.ts
@@ -28,11 +28,7 @@ describe("AnalyticsEngineAPI", () => {
 
     describe("query", () => {
         test("forms a valid HTTP request query for CF analytics engine", () => {
-            fetch.mockResolvedValue(
-                new Promise((resolve) => {
-                    resolve(createFetchResponse({}));
-                }),
-            );
+            fetch.mockResolvedValue(createFetchResponse({}));
 
             api.query("SELECT * FROM web_counter");
 
@@ -56,26 +52,22 @@ describe("AnalyticsEngineAPI", () => {
             expect(process.env.TZ).toBe("EST");
 
             fetch.mockResolvedValue(
-                new Promise((resolve) => {
-                    resolve(
-                        createFetchResponse({
-                            data: [
-                                {
-                                    count: 3,
-                                    // note: intentionally sparse data (data for some timestamps missing)
-                                    bucket: "2024-01-13 05:00:00",
-                                },
-                                {
-                                    count: 2,
-                                    bucket: "2024-01-16 05:00:00",
-                                },
-                                {
-                                    count: 1,
-                                    bucket: "2024-01-17 05:00:00",
-                                },
-                            ],
-                        }),
-                    );
+                createFetchResponse({
+                    data: [
+                        {
+                            count: 3,
+                            // note: intentionally sparse data (data for some timestamps missing)
+                            bucket: "2024-01-13 05:00:00",
+                        },
+                        {
+                            count: 2,
+                            bucket: "2024-01-16 05:00:00",
+                        },
+                        {
+                            count: 1,
+                            bucket: "2024-01-17 05:00:00",
+                        },
+                    ],
                 }),
             );
 
@@ -122,26 +114,22 @@ describe("AnalyticsEngineAPI", () => {
         expect(process.env.TZ).toBe("EST");
 
         fetch.mockResolvedValue(
-            new Promise((resolve) => {
-                resolve(
-                    createFetchResponse({
-                        data: [
-                            {
-                                count: 3,
-                                // note: intentionally sparse data (data for some timestamps missing)
-                                bucket: "2024-01-17 11:00:00",
-                            },
-                            {
-                                count: 2,
-                                bucket: "2024-01-17 14:00:00",
-                            },
-                            {
-                                count: 1,
-                                bucket: "2024-01-17 16:00:00",
-                            },
-                        ],
-                    }),
-                );
+            createFetchResponse({
+                data: [
+                    {
+                        count: 3,
+                        // note: intentionally sparse data (data for some timestamps missing)
+                        bucket: "2024-01-17 11:00:00",
+                    },
+                    {
+                        count: 2,
+                        bucket: "2024-01-17 14:00:00",
+                    },
+                    {
+                        count: 1,
+                        bucket: "2024-01-17 16:00:00",
+                    },
+                ],
             }),
         );
 
@@ -151,6 +139,7 @@ describe("AnalyticsEngineAPI", () => {
             "example.com",
             "HOUR",
             1,
+            "America/New_York",
         );
 
         // reminder results are expressed as UTC
@@ -188,28 +177,24 @@ describe("AnalyticsEngineAPI", () => {
     describe("getCounts", () => {
         test("should return an object with view, visit, and visitor counts", async () => {
             fetch.mockResolvedValue(
-                new Promise((resolve) => {
-                    resolve(
-                        createFetchResponse({
-                            data: [
-                                {
-                                    count: 3,
-                                    isVisit: 1,
-                                    isVisitor: 0,
-                                },
-                                {
-                                    count: 2,
-                                    isVisit: 0,
-                                    isVisitor: 0,
-                                },
-                                {
-                                    count: 1,
-                                    isVisit: 0,
-                                    isVisitor: 1,
-                                },
-                            ],
-                        }),
-                    );
+                createFetchResponse({
+                    data: [
+                        {
+                            count: 3,
+                            isVisit: 1,
+                            isVisitor: 0,
+                        },
+                        {
+                            count: 2,
+                            isVisit: 0,
+                            isVisitor: 0,
+                        },
+                        {
+                            count: 1,
+                            isVisit: 0,
+                            isVisitor: 1,
+                        },
+                    ],
                 }),
             );
 
@@ -228,25 +213,21 @@ describe("AnalyticsEngineAPI", () => {
     describe("getVisitorCountByColumn", () => {
         test("it should map logical columns to schema columns and return an array of [column, count] tuples", async () => {
             fetch.mockResolvedValue(
-                new Promise((resolve) => {
-                    resolve(
-                        createFetchResponse({
-                            data: [
-                                {
-                                    blob4: "CA",
-                                    count: 3,
-                                },
-                                {
-                                    blob4: "US",
-                                    count: 2,
-                                },
-                                {
-                                    blob4: "GB",
-                                    count: 1,
-                                },
-                            ],
-                        }),
-                    );
+                createFetchResponse({
+                    data: [
+                        {
+                            blob4: "CA",
+                            count: 3,
+                        },
+                        {
+                            blob4: "US",
+                            count: 2,
+                        },
+                        {
+                            blob4: "GB",
+                            count: 1,
+                        },
+                    ],
                 }),
             );
 
@@ -271,25 +252,21 @@ describe("AnalyticsEngineAPI", () => {
             // note: getSitesByHits orders by count descending in SQL; since we're mocking
             //       the HTTP/SQL response, the mocked results are pre-sorted
             fetch.mockResolvedValue(
-                new Promise((resolve) => {
-                    resolve(
-                        createFetchResponse({
-                            data: [
-                                {
-                                    siteId: "example.com",
-                                    count: 130,
-                                },
-                                {
-                                    siteId: "foo.com",
-                                    count: 100,
-                                },
-                                {
-                                    siteId: "test.dev",
-                                    count: 90,
-                                },
-                            ],
-                        }),
-                    );
+                createFetchResponse({
+                    data: [
+                        {
+                            siteId: "example.com",
+                            count: 130,
+                        },
+                        {
+                            siteId: "foo.com",
+                            count: 100,
+                        },
+                        {
+                            siteId: "test.dev",
+                            count: 90,
+                        },
+                    ],
                 }),
             );
 

--- a/app/routes/dashboard.test.tsx
+++ b/app/routes/dashboard.test.tsx
@@ -43,12 +43,8 @@ describe("Dashboard route", () => {
         test("redirects to ?site=siteId if no siteId is provided via query string", async () => {
             // response for getSitesByOrderedHits
             fetch.mockResolvedValueOnce(
-                new Promise((resolve) => {
-                    resolve(
-                        createFetchResponse({
-                            data: [{ siteId: "test-siteid", count: 1 }],
-                        }),
-                    );
+                createFetchResponse({
+                    data: [{ siteId: "test-siteid", count: 1 }],
                 }),
             );
 
@@ -69,6 +65,34 @@ describe("Dashboard route", () => {
             expect(response.status).toBe(302);
             expect(response.headers.get("Location")).toBe(
                 "http://localhost:3000/dashboard?site=test-siteid",
+            );
+        });
+
+        test("redirects to ?site= if no siteId is provided via query string / no site data", async () => {
+            // response for getSitesByOrderedHits
+            fetch.mockResolvedValueOnce(
+                createFetchResponse({
+                    data: [],
+                }),
+            );
+
+            const response = await loader({
+                context: {
+                    env: {
+                        CF_BEARER_TOKEN: "fake",
+                        CF_ACCOUNT_ID: "fake",
+                    },
+                },
+                // @ts-expect-error we don't need to provide all the properties of the request object
+                request: {
+                    url: "http://localhost:3000/dashboard", // no site query param
+                },
+            });
+
+            // expect redirect
+            expect(response.status).toBe(302);
+            expect(response.headers.get("Location")).toBe(
+                "http://localhost:3000/dashboard?site=",
             );
         });
 

--- a/app/routes/dashboard.test.tsx
+++ b/app/routes/dashboard.test.tsx
@@ -25,6 +25,38 @@ describe("Dashboard route", () => {
     });
 
     describe("loader", () => {
+        test("redirects to ?site=siteId if no siteId is provided via query string", async () => {
+            // response for getSitesByOrderedHits
+            fetch.mockResolvedValueOnce(
+                new Promise((resolve) => {
+                    resolve(
+                        createFetchResponse({
+                            data: [{ siteId: "test-siteid", count: 1 }],
+                        }),
+                    );
+                }),
+            );
+
+            const response = await loader({
+                context: {
+                    env: {
+                        CF_BEARER_TOKEN: "fake",
+                        CF_ACCOUNT_ID: "fake",
+                    },
+                },
+                // @ts-expect-error we don't need to provide all the properties of the request object
+                request: {
+                    url: "http://localhost:3000/dashboard", // no site query param
+                },
+            });
+
+            // expect redirect
+            expect(response.status).toBe(302);
+            expect(response.headers.get("Location")).toBe(
+                "http://localhost:3000/dashboard?site=test-siteid",
+            );
+        });
+
         test("assembles data returned from CF API", async () => {
             // response for getSitesByOrderedHits
             fetch.mockResolvedValueOnce(
@@ -129,7 +161,7 @@ describe("Dashboard route", () => {
                 },
                 // @ts-expect-error we don't need to provide all the properties of the request object
                 request: {
-                    url: "http://localhost:3000/dashboard",
+                    url: "http://localhost:3000/dashboard?site=test-siteid",
                 },
             });
 

--- a/app/routes/dashboard.test.tsx
+++ b/app/routes/dashboard.test.tsx
@@ -1,6 +1,14 @@
 // @vitest-environment jsdom
 import { json } from "@remix-run/node";
-import { vi, test, describe, beforeAll, expect } from "vitest";
+import {
+    vi,
+    test,
+    describe,
+    beforeAll,
+    beforeEach,
+    afterEach,
+    expect,
+} from "vitest";
 import "vitest-dom/extend-expect";
 
 import { createRemixStub } from "@remix-run/testing";
@@ -8,7 +16,6 @@ import { render, screen, waitFor } from "@testing-library/react";
 
 import Dashboard, { loader } from "./dashboard";
 
-global.fetch = vi.fn();
 function createFetchResponse(data: any) {
     return {
         ok: true,
@@ -17,11 +24,19 @@ function createFetchResponse(data: any) {
 }
 
 describe("Dashboard route", () => {
-    const fetch = global.fetch as any;
+    let fetch: any;
 
     beforeAll(() => {
         // polyfill needed for recharts (used by TimeSeriesChart)
         global.ResizeObserver = require("resize-observer-polyfill");
+    });
+
+    beforeEach(() => {
+        fetch = global.fetch = vi.fn();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     describe("loader", () => {
@@ -60,93 +75,61 @@ describe("Dashboard route", () => {
         test("assembles data returned from CF API", async () => {
             // response for getSitesByOrderedHits
             fetch.mockResolvedValueOnce(
-                new Promise((resolve) => {
-                    resolve(
-                        createFetchResponse({
-                            data: [{ siteId: "test-siteid", count: 1 }],
-                        }),
-                    );
+                createFetchResponse({
+                    data: [{ siteId: "test-siteid", count: 1 }],
                 }),
             );
 
             // response for get counts
             fetch.mockResolvedValueOnce(
-                new Promise((resolve) => {
-                    resolve(
-                        createFetchResponse({
-                            data: [
-                                { isVisit: 1, isVisitor: 1, count: 1 },
-                                { isVisit: 1, isVisitor: 0, count: 2 },
-                                { isVisit: 0, isVisitor: 0, count: 3 },
-                            ],
-                        }),
-                    );
+                createFetchResponse({
+                    data: [
+                        { isVisit: 1, isVisitor: 1, count: 1 },
+                        { isVisit: 1, isVisitor: 0, count: 2 },
+                        { isVisit: 0, isVisitor: 0, count: 3 },
+                    ],
                 }),
             );
 
             // response for getCountByPath
             fetch.mockResolvedValueOnce(
-                new Promise((resolve) => {
-                    resolve(
-                        createFetchResponse({
-                            data: [{ blob3: "/", count: 1 }],
-                        }),
-                    );
+                createFetchResponse({
+                    data: [{ blob3: "/", count: 1 }],
                 }),
             );
 
             // response for getCountByCountry
             fetch.mockResolvedValueOnce(
-                new Promise((resolve) => {
-                    resolve(
-                        createFetchResponse({
-                            data: [{ blob4: "US", count: 1 }],
-                        }),
-                    );
+                createFetchResponse({
+                    data: [{ blob4: "US", count: 1 }],
                 }),
             );
 
             // response for getCountByReferrer
             fetch.mockResolvedValueOnce(
-                new Promise((resolve) => {
-                    resolve(
-                        createFetchResponse({
-                            data: [{ blob5: "google.com", count: 1 }],
-                        }),
-                    );
+                createFetchResponse({
+                    data: [{ blob5: "google.com", count: 1 }],
                 }),
             );
 
             // response for getCountByBrowser
             fetch.mockResolvedValueOnce(
-                new Promise((resolve) => {
-                    resolve(
-                        createFetchResponse({
-                            data: [{ blob6: "Chrome", count: 2 }],
-                        }),
-                    );
+                createFetchResponse({
+                    data: [{ blob6: "Chrome", count: 2 }],
                 }),
             );
 
             // response for getCountByDevice
             fetch.mockResolvedValueOnce(
-                new Promise((resolve) => {
-                    resolve(
-                        createFetchResponse({
-                            data: [{ blob7: "Desktop", count: 3 }],
-                        }),
-                    );
+                createFetchResponse({
+                    data: [{ blob7: "Desktop", count: 3 }],
                 }),
             );
 
             // response for getViewsGroupedByInterval
             fetch.mockResolvedValueOnce(
-                new Promise((resolve) => {
-                    resolve(
-                        createFetchResponse({
-                            data: [{ bucket: "2024-01-11 00:00:00", count: 4 }],
-                        }),
-                    );
+                createFetchResponse({
+                    data: [{ bucket: "2024-01-11 00:00:00", count: 4 }],
                 }),
             );
 
@@ -180,6 +163,58 @@ describe("Dashboard route", () => {
                 countByDevice: [["Desktop", 3]],
                 viewsGroupedByInterval: [
                     ["2024-01-11 00:00:00", 4],
+                    ["2024-01-12 00:00:00", 0],
+                    ["2024-01-13 00:00:00", 0],
+                    ["2024-01-14 00:00:00", 0],
+                    ["2024-01-15 00:00:00", 0],
+                    ["2024-01-16 00:00:00", 0],
+                    ["2024-01-17 00:00:00", 0],
+                    ["2024-01-18 00:00:00", 0],
+                ],
+                intervalType: "DAY",
+            });
+        });
+
+        test("returns a valid empty result set when no data (no sites, no anything)", async () => {
+            vi.setSystemTime(new Date("2024-01-18T09:33:02").getTime());
+
+            fetch.mockResolvedValueOnce(createFetchResponse({ data: [] })); // getSitesOrderedByHits
+            fetch.mockResolvedValueOnce(createFetchResponse({ data: [] })); // get counts
+            fetch.mockResolvedValueOnce(createFetchResponse({ data: [] })); // getCountByPath
+            fetch.mockResolvedValueOnce(createFetchResponse({ data: [] })); // getCountByCountry
+            fetch.mockResolvedValueOnce(createFetchResponse({ data: [] })); // getCountByReferrer
+            fetch.mockResolvedValueOnce(createFetchResponse({ data: [] })); // getCountByBrowser
+            fetch.mockResolvedValueOnce(createFetchResponse({ data: [] })); // getCountByDevice
+            fetch.mockResolvedValueOnce(createFetchResponse({ data: [] })); // getViewsGroupedByInterval
+
+            const response = await loader({
+                context: {
+                    env: {
+                        CF_BEARER_TOKEN: "fake",
+                        CF_ACCOUNT_ID: "fake",
+                    },
+                },
+                // @ts-expect-error we don't need to provide all the properties of the request object
+                request: {
+                    url: "http://localhost:3000/dashboard?site=", // intentionally empty
+                },
+            });
+
+            const json = await response.json();
+
+            expect(json).toEqual({
+                siteId: "",
+                sites: [],
+                views: 0,
+                visits: 0,
+                visitors: 0,
+                countByPath: [],
+                countByCountry: [],
+                countByReferrer: [],
+                countByBrowser: [],
+                countByDevice: [],
+                viewsGroupedByInterval: [
+                    ["2024-01-11 00:00:00", 0],
                     ["2024-01-12 00:00:00", 0],
                     ["2024-01-13 00:00:00", 0],
                     ["2024-01-14 00:00:00", 0],

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -57,15 +57,13 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
             await analyticsEngine.getSitesOrderedByHits(interval);
 
         // if at least one result
-        if (sitesByHits.length > 0 && sitesByHits[0].length > 0) {
-            const redirectUrl = new URL(request.url);
-            redirectUrl.searchParams.set("site", sitesByHits[0][0]);
-            return redirect(redirectUrl.toString());
-        }
+        const redirectSite = sitesByHits[0]?.[0] || "";
+        const redirectUrl = new URL(request.url);
+        redirectUrl.searchParams.set("site", redirectSite);
+        return redirect(redirectUrl.toString());
     }
-
-    // treat "@unknown" as a magic string to identify AE records where no siteId was set
     const siteId = url.searchParams.get("site") || "";
+
     const actualSiteId = siteId == "@unknown" ? "" : siteId;
 
     // initiate requests to AE in parallel
@@ -114,11 +112,9 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
         tz,
     );
 
-    console.log("got here");
-
     // await all requests to AE then return the results
     return json({
-        siteId: siteId || "@unknown",
+        siteId: siteId,
         sites: (await sitesByHits).map(([site]: [string]) => site),
         views: (await counts).views,
         visits: (await counts).visits,


### PR DESCRIPTION
This has a couple of benefits:

* After redirect, doesn't wait for `getSitesOrderedByHits` to finish before querying data (no blocking before fetching data; faster)
* Avoids situations where different URLs could generate the same document (better consistency IMO), i.e. we were loading a default site at `/dashboard` and this would generate the same document as `/dashboard?site=default`
* No longer throws when there is no data in the AE dataset (fixes #24)
* Removes unnecessary Promise layer in test code (when mocking responses via `fetch.mockResolvedValue)`