### PR TITLE
Configure ts so it doesnt error on lib types, allowing it to be enabled precommit (or in ci)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -13,5 +13,6 @@ echo "$FILES" | xargs git add
 
 npm test
 npm run lint
+npm run typecheck
 
 exit 0

--- a/app/analytics/collect.test.ts
+++ b/app/analytics/collect.test.ts
@@ -89,7 +89,7 @@ describe("collectRequestHandler", () => {
             [
                 1, // new visitor
                 1, // new session
-            ],
+            ]
         );
     });
 
@@ -100,13 +100,13 @@ describe("collectRequestHandler", () => {
             } as CFAnalyticsEngine,
         } as Environment;
 
-        // @ts-expect-error - we're mocking the request object
         const request = httpMocks.createRequest(
+            // @ts-expect-error - we're mocking the request object
             generateRequestParams({
                 "if-modified-since": new Date(
-                    Date.now() - 5 * 60 * 1000,
+                    Date.now() - 5 * 60 * 1000
                 ).toUTCString(),
-            }),
+            })
         );
 
         collectRequestHandler(request, env);
@@ -117,7 +117,7 @@ describe("collectRequestHandler", () => {
             [
                 0, // new visitor
                 0, // new session
-            ],
+            ]
         );
     });
 
@@ -128,13 +128,13 @@ describe("collectRequestHandler", () => {
             } as CFAnalyticsEngine,
         } as Environment;
 
-        // @ts-expect-error - we're mocking the request object
         const request = httpMocks.createRequest(
+            // @ts-expect-error - we're mocking the request object
             generateRequestParams({
                 "if-modified-since": new Date(
-                    Date.now() - 31 * 60 * 1000,
+                    Date.now() - 31 * 60 * 1000
                 ).toUTCString(),
-            }),
+            })
         );
 
         collectRequestHandler(request, env);
@@ -145,7 +145,7 @@ describe("collectRequestHandler", () => {
             [
                 0, // new visitor
                 1, // new session
-            ],
+            ]
         );
     });
 
@@ -156,13 +156,13 @@ describe("collectRequestHandler", () => {
             } as CFAnalyticsEngine,
         } as Environment;
 
-        // @ts-expect-error - we're mocking the request object
         const request = httpMocks.createRequest(
+            // @ts-expect-error - we're mocking the request object
             generateRequestParams({
                 "if-modified-since": new Date(
-                    Date.now() - 60 * 24 * 60 * 1000,
+                    Date.now() - 60 * 24 * 60 * 1000
                 ).toUTCString(),
-            }),
+            })
         );
 
         collectRequestHandler(request, env);
@@ -173,7 +173,7 @@ describe("collectRequestHandler", () => {
             [
                 1, // new visitor
                 1, // new session
-            ],
+            ]
         );
     });
 });

--- a/app/analytics/query.ts
+++ b/app/analytics/query.ts
@@ -61,7 +61,7 @@ function formatDateString(d: Date) {
 function generateEmptyRowsOverInterval(
     intervalType: string,
     daysAgo: number,
-    tz?: string,
+    tz?: string
 ): [Date, any] {
     if (!tz) {
         tz = "Etc/UTC";
@@ -96,7 +96,7 @@ function generateEmptyRowsOverInterval(
         const rowDate = new Date(i);
         // convert to UTC
         const utcDateTime = new Date(
-            rowDate.getTime() + rowDate.getTimezoneOffset() * 60_000,
+            rowDate.getTime() + rowDate.getTimezoneOffset() * 60_000
         );
 
         const key = formatDateString(utcDateTime);
@@ -151,7 +151,7 @@ export class AnalyticsEngineAPI {
         siteId: string,
         intervalType: string,
         sinceDays: number,
-        tz: string,
+        tz?: string
     ): Promise<any> {
         let intervalCount = 1;
 
@@ -167,7 +167,7 @@ export class AnalyticsEngineAPI {
         const [startDateTime, initialRows] = generateEmptyRowsOverInterval(
             intervalType,
             sinceDays,
-            tz,
+            tz
         );
 
         // NOTE: when using toStartOfInterval, cannot group by other columns
@@ -210,7 +210,7 @@ export class AnalyticsEngineAPI {
                         accum[key] = row["count"];
                         return accum;
                     },
-                    initialRows,
+                    initialRows
                 );
 
                 // return as sorted array of tuples (i.e. [datetime, count])
@@ -219,18 +219,18 @@ export class AnalyticsEngineAPI {
                         if (a[0] < b[0]) return -1;
                         else if (a[0] > b[0]) return 1;
                         else return 0;
-                    },
+                    }
                 );
 
                 resolve(sortedRows);
-            })(),
+            })()
         );
         return returnPromise;
     }
 
     async getCounts(
         siteId: string,
-        sinceDays: number,
+        sinceDays: number
     ): Promise<AnalyticsCountResult> {
         // defaults to 1 day if not specified
         const interval = sinceDays || 1;
@@ -277,7 +277,7 @@ export class AnalyticsEngineAPI {
                         counts.views += Number(row.count);
                     });
                     resolve(counts);
-                })(),
+                })()
         );
 
         return returnPromise;
@@ -287,7 +287,7 @@ export class AnalyticsEngineAPI {
         siteId: string,
         column: string,
         sinceDays: number,
-        limit?: number,
+        limit?: number
     ): Promise<any> {
         // defaults to 1 day if not specified
         const interval = sinceDays || 1;
@@ -320,9 +320,9 @@ export class AnalyticsEngineAPI {
                         const key =
                             row[_column] === "" ? "(none)" : row[_column];
                         return [key, row["count"]];
-                    }),
+                    })
                 );
-            })(),
+            })()
         );
         return returnPromise;
     }
@@ -353,7 +353,7 @@ export class AnalyticsEngineAPI {
 
     async getSitesOrderedByHits(
         sinceDays: number,
-        limit?: number,
+        limit?: number
     ): Promise<any> {
         // defaults to 1 day if not specified
         const interval = sinceDays || 1;
@@ -387,7 +387,7 @@ export class AnalyticsEngineAPI {
                 }, []);
 
                 resolve(result);
-            })(),
+            })()
         );
         return returnPromise;
     }

--- a/app/analytics/query.ts
+++ b/app/analytics/query.ts
@@ -151,7 +151,8 @@ export class AnalyticsEngineAPI {
         siteId: string,
         intervalType: string,
         sinceDays: number,
-        tz?: string {
+        tz?: string
+    ) {
         let intervalCount = 1;
 
         // keeping this code here once we start allowing bigger intervals (e.g. intervals of 2 hours)

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -19,9 +19,10 @@ export default async function handleRequest(
     // free to delete this parameter in your app if you're not using it!
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    loadContext: AppLoadContext,
+    loadContext: AppLoadContext
 ) {
     const body = await renderToReadableStream(
+        // @ts-expect-error This is a mistake in the package types, resolved in @remix-run/react@2.5.1
         <RemixServer context={remixContext} url={request.url} />,
         {
             signal: request.signal,
@@ -30,7 +31,7 @@ export default async function handleRequest(
                 console.error(error);
                 responseStatusCode = 500;
             },
-        },
+        }
     );
 
     if (isbot(request.headers.get("user-agent"))) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
             "~/*": ["./app/*"]
         },
         // Remix takes care of building everything in `remix build`.
-        "noEmit": true
+        "noEmit": true,
+        "skipLibCheck": true
     }
 }


### PR DESCRIPTION
Setting `skipLibCheck` prevents typescript from checking your node_modules for errors. With this setting on, there were only a couple of small things to clean up, which means you can enforce type correctness.

This is probably better as a ci check rather than precommit hook, let me know if you agree and I can change it.