### PR TITLE
Adds typechecking to the ci checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ jobs:
             - run: npm install
             - run: npm run lint
             - run: npm run build
+            - run: npm run typecheck
             - run: npm run test-ci
             - name: Upload coverage reports to Codecov
               uses: codecov/codecov-action@v3


### PR DESCRIPTION
Now that types are in place, it would be a good idea to enforce proper types on PRs before merging. 