### PR TITLE
Render views + visitors in table card by path

### DIFF
--- a/app/analytics/query.ts
+++ b/app/analytics/query.ts
@@ -429,15 +429,13 @@ export class AnalyticsEngineAPI {
         );
 
         return allCountsResultPromise.then((allCountsResult) => {
-            // return new Promise<[string, number, number][]>(async (resolve) => {
-            //     const allCountsResult = await allCountsResultPromise;
-
             const result: [string, number, number][] = [];
             for (const [key] of Object.entries(allCountsResult)) {
                 const record = allCountsResult[key];
                 result.push([key, record.visitors, record.views]);
             }
-            return result;
+            // sort by visitors
+            return result.sort((a, b) => b[1] - a[1]);
         });
     }
 

--- a/app/components/TableCard.tsx
+++ b/app/components/TableCard.tsx
@@ -61,9 +61,16 @@ export default function TableCard({
                             >
                                 {item[0]}
                             </TableCell>
+
                             <TableCell className="text-right w-1/5">
                                 {item[1]}
                             </TableCell>
+
+                            {item.length > 2 && (
+                                <TableCell className="text-right w-1/5">
+                                    {item[2]}
+                                </TableCell>
+                            )}
                         </TableRow>
                     ))}
                 </TableBody>

--- a/app/routes/dashboard.test.tsx
+++ b/app/routes/dashboard.test.tsx
@@ -140,7 +140,10 @@ describe("Dashboard route", () => {
             // response for getCountByPath
             fetch.mockResolvedValueOnce(
                 createFetchResponse({
-                    data: [{ blob3: "/", count: 1 }],
+                    data: [
+                        { blob3: "/", count: 1, isVisitor: 1, isVisit: 1 },
+                        { blob3: "/", count: 3, isVisitor: 0, isVisit: 0 },
+                    ],
                 }),
             );
 
@@ -203,7 +206,7 @@ describe("Dashboard route", () => {
                 views: 6,
                 visits: 3,
                 visitors: 1,
-                countByPath: [["/", 1]],
+                countByPath: [["/", 1, 4]],
                 countByCountry: [["US", 1]],
                 countByReferrer: [["google.com", 1]],
                 countByBrowser: [["Chrome", 2]],

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -261,7 +261,7 @@ export default function Dashboard() {
             <div className="grid md:grid-cols-2 gap-4 mb-4">
                 <TableCard
                     countByProperty={data.countByPath}
-                    columnHeaders={["Page", "Visitors", "Visits"]}
+                    columnHeaders={["Page", "Visitors", "Views"]}
                 />
 
                 <TableCard

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -261,7 +261,7 @@ export default function Dashboard() {
             <div className="grid md:grid-cols-2 gap-4 mb-4">
                 <TableCard
                     countByProperty={data.countByPath}
-                    columnHeaders={["Page", "Visitors"]}
+                    columnHeaders={["Page", "Visitors", "Visits"]}
                 />
 
                 <TableCard


### PR DESCRIPTION
Introduces a new method, `getAllCountsByColumn`, which returns `visits`, `views`, and `visitors` for a given column (e.g. path, referrer, etc). Then modifies the "Counts by Path" table card to fetch that data and render multiple columns.

I decided to sort by visitors, because that's usually what I care about, but it could be views instead.

![image](https://github.com/benvinegar/counterscale/assets/2153/0bc75fc9-2325-4c35-82c9-f0f6929bca19)

Fixes #12