### PR TITLE
Fix bad date calculations along DST boundaries

### DIFF
--- a/app/analytics/query.ts
+++ b/app/analytics/query.ts
@@ -107,6 +107,18 @@ function generateEmptyRowsOverInterval(
 
     const initialRows: { [key: string]: number } = {};
 
+    // NOTE: Need to explicitly use dayjs to increment by 1 day/1 hour/etc, because
+    //       dayjs will respect and adjust for daylight savings time boundaries.
+    //
+    //       For example, in 2024, Daylight Savings Time began on 3/10/24 at 2:00 AM.
+    //       In UTC, before the switch, America/New_York was 5 hours behind UTC (+5:00).
+    //       But after the switch, it becomes 4 hours behind UTC (+4:00). Dayjs
+    //       accounts for this difference.
+    //
+    //       There is no unit test affirming this behavior, because I could not figure
+    //       out how to get vitest/mock dates to recreate DST changes.
+    //       See: https://github.com/benvinegar/counterscale/pull/62
+
     while (startDateTime.getTime() < Date.now()) {
         const key = dayjs(startDateTime).utc().format("YYYY-MM-DD HH:mm:ss");
         initialRows[key] = 0;

--- a/app/analytics/query.ts
+++ b/app/analytics/query.ts
@@ -105,13 +105,6 @@ function generateEmptyRowsOverInterval(
         tz = "Etc/UTC";
     }
 
-    let intervalMs = 0;
-    if (intervalType === "DAY") {
-        intervalMs = 24 * 60 * 60 * 1000;
-    } else if (intervalType === "HOUR") {
-        intervalMs = 60 * 60 * 1000;
-    }
-
     const initialRows: { [key: string]: number } = {};
 
     while (startDateTime.getTime() < Date.now()) {
@@ -119,6 +112,7 @@ function generateEmptyRowsOverInterval(
         initialRows[key] = 0;
 
         startDateTime = dayjs(startDateTime)
+            // increment by either DAY or HOUR
             .add(1, intervalType.toLowerCase() as ManipulateType)
             .toDate();
     }

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -103,7 +103,7 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
         tz,
     );
 
-    let intervalType = "DAY";
+    let intervalType: "DAY" | "HOUR" = "DAY";
     switch (interval) {
         case "today":
         case "1d":


### PR DESCRIPTION
Fix #61 (and might also ref #60)

This uses `dayjs` to increment hours and days when generating buckets in JS (to account for a lack of `COALESCE` SQL function in CF AE, see comment below), vs using fixed intervals which didn't account for DST boundaries and introduced other issues (naive mistake, oops).

This deserves to have tests. I tried doing an initial test for the DST boundaries but couldn't replicate the behavior I was experiencing when running the dev server (possibly because the Date object is mocked in `vitest` – not sure, haven't spent much time looking into this).