### PR TITLE
Fix bad hourly start timestamp on chart data

### DIFF
--- a/app/analytics/query.ts
+++ b/app/analytics/query.ts
@@ -42,30 +42,6 @@ function accumulateCountsFromRowResult(
     counts.views += Number(row.count);
 }
 
-/**
- * Convert a Date object to YY-MM-DD HH:MM:SS
- */
-function formatDateString(d: Date) {
-    function pad(n: number) {
-        return n < 10 ? "0" + n : n;
-    }
-    const dash = "-";
-    const colon = ":";
-    return (
-        d.getFullYear() +
-        dash +
-        pad(d.getMonth() + 1) +
-        dash +
-        pad(d.getDate()) +
-        " " +
-        pad(d.getHours()) +
-        colon +
-        pad(d.getMinutes()) +
-        colon +
-        pad(d.getSeconds())
-    );
-}
-
 function intervalToSql(interval: string, tz?: string) {
     let intervalSql = "";
     switch (interval) {
@@ -243,7 +219,9 @@ export class AnalyticsEngineAPI {
                     const rowsByDateTime = responseData.data.reduce(
                         (accum, row) => {
                             const utcDateTime = new Date(row["bucket"]);
-                            const key = formatDateString(utcDateTime);
+                            const key = dayjs(utcDateTime).format(
+                                "YYYY-MM-DD HH:mm:ss",
+                            );
                             accum[key] = Number(row["count"]);
                             return accum;
                         },


### PR DESCRIPTION
Fixes #60 

Originally this tried to do some clever tz math inside Analytics Engine, but it doesn't work. Instead just explicitly calculate the utc start time, treat everything as utc, then convert back to local during UI rendering.

Also removes `formatDateString` because I think it was also doing some implicit timezone conversion in there somewhere. I found `dayjs` to be more predictable.