### PR TITLE
Instead of tables, use divs + css grid

### DIFF
--- a/app/components/TableCard.tsx
+++ b/app/components/TableCard.tsx
@@ -34,11 +34,16 @@ export default function TableCard({
     );
 
     const countFormatter = Intl.NumberFormat("en", { notation: "compact" });
+
+    const gridCols =
+        (columnHeaders || []).length === 3
+            ? "grid-cols-[minmax(0,1fr),minmax(0,8ch),minmax(0,8ch)]"
+            : "grid-cols-[minmax(0,1fr),minmax(0,8ch)]";
     return (
         <Card>
             <Table>
                 <TableHeader>
-                    <TableRow>
+                    <TableRow className={`${gridCols}`}>
                         {(columnHeaders || []).map((header: string, index) => (
                             <TableHead
                                 key={header}
@@ -55,12 +60,10 @@ export default function TableCard({
                     {(countByProperty || []).map((item, key) => (
                         <TableRow
                             key={item[0]}
-                            className="group [&_td]:last:rounded-b-md"
+                            className={`group [&_td]:last:rounded-b-md ${gridCols}`}
+                            width={barChartPercentages[key]}
                         >
-                            <TableCell
-                                className="font-medium w-full break-all"
-                                width={barChartPercentages[key]}
-                            >
+                            <TableCell className="font-medium min-w-48 break-all">
                                 {item[0]}
                             </TableCell>
 

--- a/app/components/ui/table.tsx
+++ b/app/components/ui/table.tsx
@@ -8,7 +8,7 @@ const Table = React.forwardRef<
     React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
     <div className="relative w-full overflow-auto">
-        <table
+        <div
             ref={ref}
             className={cn("w-full caption-bottom text-sm", className)}
             {...props}
@@ -21,7 +21,11 @@ const TableHeader = React.forwardRef<
     HTMLTableSectionElement,
     React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-    <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+    <div
+        ref={ref}
+        className={cn("[&_tr]:border-b grid", className)}
+        {...props}
+    />
 ));
 TableHeader.displayName = "TableHeader";
 
@@ -29,7 +33,7 @@ const TableBody = React.forwardRef<
     HTMLTableSectionElement,
     React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-    <tbody
+    <div
         ref={ref}
         className={cn("[&_tr:last-child]:border-0", className)}
         {...props}
@@ -41,7 +45,7 @@ const TableFooter = React.forwardRef<
     HTMLTableSectionElement,
     React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-    <tfoot
+    <div
         ref={ref}
         className={cn(
             "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
@@ -54,27 +58,37 @@ TableFooter.displayName = "TableFooter";
 
 const TableRow = React.forwardRef<
     HTMLTableRowElement,
-    React.HTMLAttributes<HTMLTableRowElement>
->(({ className, ...props }, ref) => (
-    <tr
-        ref={ref}
-        className={cn(
-            "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
-            className,
-        )}
-        {...props}
-    />
-));
+    React.HTMLAttributes<HTMLTableRowElement> & { width?: string } // Add 'width' property to the type definition
+>(({ className, ...props }, ref) => {
+    const { width } = props;
+    return (
+        <div
+            ref={ref}
+            className={cn(
+                `grid border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted`,
+                className,
+            )}
+            style={
+                width !== undefined
+                    ? {
+                          background: `linear-gradient(90deg, #F7BA70 ${width}, transparent ${width})`,
+                      }
+                    : {}
+            }
+            {...props}
+        />
+    );
+});
 TableRow.displayName = "TableRow";
 
 const TableHead = React.forwardRef<
     HTMLTableCellElement,
     React.ThHTMLAttributes<HTMLTableCellElement>
 >(({ className, ...props }, ref) => (
-    <th
+    <div
         ref={ref}
         className={cn(
-            "h-12 px-4 text-left align-middle font-medium [&:has([role=checkbox])]:pr-0",
+            "h-12 p-4 text-left align-middle font-medium [&:has([role=checkbox])]:pr-0",
             className,
         )}
         {...props}
@@ -85,20 +99,13 @@ TableHead.displayName = "TableHead";
 const TableCell = React.forwardRef<
     HTMLTableCellElement,
     React.TdHTMLAttributes<HTMLTableCellElement> & { width?: string }
->(({ className, width, ...props }, ref) => (
-    <td
+>(({ className, ...props }, ref) => (
+    <div
         ref={ref}
         className={cn(
             "p-4 align-middle [&:has([role=checkbox])]:pr-0",
             className,
         )}
-        style={
-            width !== undefined
-                ? {
-                      background: `linear-gradient(90deg, #F7BA70 ${width}, transparent ${width})`,
-                  }
-                : {}
-        }
         {...props}
     />
 ));


### PR DESCRIPTION
This fixes the background color on table rows not going all the way across the row, which was a limitation of `table` elements.

After this PR, the background color actually takes up X% of the row.

Before:

![image](https://github.com/benvinegar/counterscale/assets/2153/2adca4ef-1b80-4e21-ac57-55a7ef553dd8)

After:
![image](https://github.com/benvinegar/counterscale/assets/2153/42d22d30-2a95-4e92-980b-0bd9b61ca1d7)

