### PR TITLE
Feature: Drill-down filters when clicking table rows [draft]

### DIFF
--- a/app/analytics/query.ts
+++ b/app/analytics/query.ts
@@ -109,12 +109,12 @@ function generateEmptyRowsOverInterval(
 }
 
 function filtersToSql(filters: Record<string, string> = {}) {
-    const supportedFilters = [
+    const supportedFilters: Array<keyof typeof ColumnMappings> = [
         "path",
         "referrer",
-        "browser",
+        "browserName",
         "country",
-        "device",
+        "deviceModel",
     ];
 
     let filterStr = "";

--- a/app/analytics/query.ts
+++ b/app/analytics/query.ts
@@ -1,5 +1,7 @@
 import { ColumnMappingToType, ColumnMappings } from "./schema";
 
+import { SearchFilters } from "~/lib/types";
+
 import dayjs, { ManipulateType } from "dayjs";
 import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
@@ -108,8 +110,8 @@ function generateEmptyRowsOverInterval(
     return initialRows;
 }
 
-function filtersToSql(filters: Record<string, string> = {}) {
-    const supportedFilters: Array<keyof typeof ColumnMappings> = [
+function filtersToSql(filters: SearchFilters) {
+    const supportedFilters: Array<keyof SearchFilters> = [
         "path",
         "referrer",
         "browserName",
@@ -172,7 +174,7 @@ export class AnalyticsEngineAPI {
         intervalType: "DAY" | "HOUR",
         startDateTime: Date, // start date/time in local timezone
         tz?: string, // local timezone
-        filters?: any,
+        filters: SearchFilters = {},
     ) {
         let intervalCount = 1;
 
@@ -272,7 +274,7 @@ export class AnalyticsEngineAPI {
         siteId: string,
         interval: string,
         tz?: string,
-        filters?: any,
+        filters: SearchFilters = {},
     ) {
         // defaults to 1 day if not specified
         const siteIdColumn = ColumnMappings["siteId"];
@@ -335,7 +337,7 @@ export class AnalyticsEngineAPI {
         column: T,
         interval: string,
         tz?: string,
-        filters: any = {},
+        filters: SearchFilters = {},
         page: number = 1,
         limit: number = 10,
     ) {
@@ -400,7 +402,7 @@ export class AnalyticsEngineAPI {
         column: T,
         interval: string,
         tz?: string,
-        filters: any = {},
+        filters: SearchFilters = {},
         page: number = 1,
         limit: number = 10,
     ) {
@@ -480,7 +482,7 @@ export class AnalyticsEngineAPI {
         siteId: string,
         interval: string,
         tz?: string,
-        filters: any = {},
+        filters: SearchFilters = {},
         page: number = 1,
     ) {
         const allCountsResultPromise = this.getAllCountsByColumn(
@@ -501,21 +503,6 @@ export class AnalyticsEngineAPI {
             // sort by visitors
             return result.sort((a, b) => b[1] - a[1]);
         });
-    }
-
-    async getCountByUserAgent(
-        siteId: string,
-        interval: string,
-        tz?: string,
-        page: number = 1,
-    ) {
-        return this.getVisitorCountByColumn(
-            siteId,
-            "userAgent",
-            interval,
-            tz,
-            page,
-        );
     }
 
     async getCountByCountry(

--- a/app/analytics/query.ts
+++ b/app/analytics/query.ts
@@ -509,7 +509,7 @@ export class AnalyticsEngineAPI {
         siteId: string,
         interval: string,
         tz?: string,
-        filters: any = {},
+        filters: SearchFilters = {},
         page: number = 1,
     ) {
         return this.getVisitorCountByColumn(
@@ -526,7 +526,7 @@ export class AnalyticsEngineAPI {
         siteId: string,
         interval: string,
         tz?: string,
-        filters: any = {},
+        filters: SearchFilters = {},
         page: number = 1,
     ) {
         return this.getVisitorCountByColumn(
@@ -542,7 +542,7 @@ export class AnalyticsEngineAPI {
         siteId: string,
         interval: string,
         tz?: string,
-        filters: any = {},
+        filters: SearchFilters = {},
         page: number = 1,
     ) {
         return this.getVisitorCountByColumn(
@@ -559,7 +559,7 @@ export class AnalyticsEngineAPI {
         siteId: string,
         interval: string,
         tz?: string,
-        filters: any = {},
+        filters: SearchFilters = {},
         page: number = 1,
     ) {
         return this.getVisitorCountByColumn(

--- a/app/analytics/query.ts
+++ b/app/analytics/query.ts
@@ -366,7 +366,7 @@ export class AnalyticsEngineAPI {
 
         const queryResult = this.query(query);
         const returnPromise = new Promise<
-            [ColumnMappingToType<typeof _column> | "(none)", number][]
+            [ColumnMappingToType<typeof _column>, number][]
         >((resolve, reject) =>
             (async () => {
                 const response = await queryResult;
@@ -387,8 +387,7 @@ export class AnalyticsEngineAPI {
 
                 resolve(
                     pageData.map((row) => {
-                        const key =
-                            row[_column] === "" ? "(none)" : row[_column];
+                        const key = row[_column];
                         return [key, row["count"]] as const;
                     }),
                 );
@@ -455,10 +454,7 @@ export class AnalyticsEngineAPI {
 
                     const result = pageData.reduce(
                         (acc, row) => {
-                            const key =
-                                row[_column] === ""
-                                    ? "(none)"
-                                    : (row[_column] as string);
+                            const key = row[_column] as string;
                             if (!Object.hasOwn(acc, key)) {
                                 acc[key] = {
                                     views: 0,

--- a/app/analytics/query.ts
+++ b/app/analytics/query.ts
@@ -108,23 +108,21 @@ function generateEmptyRowsOverInterval(
     return initialRows;
 }
 
-function filtersToSql(filters: any) {
+function filtersToSql(filters: Record<string, string> = {}) {
+    const supportedFilters = [
+        "path",
+        "referrer",
+        "browser",
+        "country",
+        "device",
+    ];
+
     let filterStr = "";
-    if (filters && filters.path) {
-        filterStr += `AND ${ColumnMappings.path} = '${filters.path}'`;
-    }
-    if (filters && filters.referrer) {
-        filterStr += `AND ${ColumnMappings.referrer} = '${filters.referrer}'`;
-    }
-    if (filters && filters.browser) {
-        filterStr += `AND ${ColumnMappings.browserName} = '${filters.browser}'`;
-    }
-    if (filters && filters.country) {
-        filterStr += `AND ${ColumnMappings.country} = '${filters.country}'`;
-    }
-    if (filters && filters.device) {
-        filterStr += `AND ${ColumnMappings.deviceModel} = '${filters.device}'`;
-    }
+    supportedFilters.forEach((filter) => {
+        if (Object.hasOwnProperty.call(filters, filter)) {
+            filterStr += `AND ${(ColumnMappings as any)[filter]} = '${filters[filter]}'`;
+        }
+    });
     return filterStr;
 }
 
@@ -357,7 +355,6 @@ export class AnalyticsEngineAPI {
             ORDER BY count DESC
             LIMIT ${limit * page}`;
 
-        console.log(query);
         type SelectionSet = {
             count: number;
         } & Record<
@@ -525,6 +522,7 @@ export class AnalyticsEngineAPI {
         siteId: string,
         interval: string,
         tz?: string,
+        filters: any = {},
         page: number = 1,
     ) {
         return this.getVisitorCountByColumn(
@@ -532,6 +530,7 @@ export class AnalyticsEngineAPI {
             "country",
             interval,
             tz,
+            filters,
             page,
         );
     }
@@ -556,6 +555,7 @@ export class AnalyticsEngineAPI {
         siteId: string,
         interval: string,
         tz?: string,
+        filters: any = {},
         page: number = 1,
     ) {
         return this.getVisitorCountByColumn(
@@ -563,6 +563,7 @@ export class AnalyticsEngineAPI {
             "browserName",
             interval,
             tz,
+            filters,
             page,
         );
     }
@@ -571,6 +572,7 @@ export class AnalyticsEngineAPI {
         siteId: string,
         interval: string,
         tz?: string,
+        filters: any = {},
         page: number = 1,
     ) {
         return this.getVisitorCountByColumn(
@@ -578,6 +580,7 @@ export class AnalyticsEngineAPI {
             "deviceModel",
             interval,
             tz,
+            filters,
             page,
         );
     }

--- a/app/analytics/query.ts
+++ b/app/analytics/query.ts
@@ -120,7 +120,7 @@ function filtersToSql(filters: Record<string, string> = {}) {
     let filterStr = "";
     supportedFilters.forEach((filter) => {
         if (Object.hasOwnProperty.call(filters, filter)) {
-            filterStr += `AND ${(ColumnMappings as any)[filter]} = '${filters[filter]}'`;
+            filterStr += `AND ${ColumnMappings[filter]} = '${filters[filter]}'`;
         }
     });
     return filterStr;

--- a/app/analytics/schema.ts
+++ b/app/analytics/schema.ts
@@ -9,6 +9,7 @@ export type ColumnMappingToType<
 /**
  * This maps logical column names to the actual column names in the data store.
  */
+
 export const ColumnMappings = {
     /**
      * blobs

--- a/app/components/PaginatedTableCard.tsx
+++ b/app/components/PaginatedTableCard.tsx
@@ -9,6 +9,7 @@ const PaginatedTableCard = ({
     interval,
     dataFetcher,
     columnHeaders,
+    filters,
     loaderUrl,
     onClick,
 }: {
@@ -16,16 +17,22 @@ const PaginatedTableCard = ({
     interval: string;
     dataFetcher: any; // ignore type for now
     columnHeaders: string[];
+    filters: Record<string, string>;
     loaderUrl: string;
     onClick?: Function;
 }) => {
     const countsByProperty = dataFetcher.data?.countsByProperty || [];
     const page = dataFetcher.data?.page || 1;
 
+    // turn filters into query string
+    const filterString = filters
+        ? Object.entries(filters).map(([key, value]) => `&${key}=${value}`)
+        : "";
+
     useEffect(() => {
         if (dataFetcher.state === "idle") {
             dataFetcher.load(
-                `${loaderUrl}?site=${siteId}&interval=${interval}`,
+                `${loaderUrl}?site=${siteId}&interval=${interval}${filterString}`,
             );
         }
     }, []);
@@ -33,14 +40,14 @@ const PaginatedTableCard = ({
     useEffect(() => {
         if (dataFetcher.state === "idle") {
             dataFetcher.load(
-                `${loaderUrl}?site=${siteId}&interval=${interval}`,
+                `${loaderUrl}?site=${siteId}&interval=${interval}${filterString}`,
             );
         }
     }, [siteId, interval]);
 
     function handlePagination(page: number) {
         dataFetcher.load(
-            `${loaderUrl}?site=${siteId}&interval=${interval}&page=${page}`,
+            `${loaderUrl}?site=${siteId}&interval=${interval}&page=${page}${filterString}`,
         );
     }
 

--- a/app/components/PaginatedTableCard.tsx
+++ b/app/components/PaginatedTableCard.tsx
@@ -27,7 +27,9 @@ const PaginatedTableCard = ({
     const loadData = (page: string | undefined = undefined) => {
         // turn filters into query string
         const filterString = filters
-            ? Object.entries(filters).map(([key, value]) => `&${key}=${value}`)
+            ? Object.entries(filters)
+                  .map(([key, value]) => `&${key}=${value}`)
+                  .join("")
             : "";
 
         let url = `${loaderUrl}?site=${siteId}&interval=${interval}${filterString}`;

--- a/app/components/PaginatedTableCard.tsx
+++ b/app/components/PaginatedTableCard.tsx
@@ -4,18 +4,20 @@ import TableCard from "~/components/TableCard";
 import { Card } from "./ui/card";
 import PaginationButtons from "./PaginationButtons";
 
-const ReferrerCard = ({
+const PaginatedTableCard = ({
     siteId,
     interval,
     dataFetcher,
     columnHeaders,
     loaderUrl,
+    onClick,
 }: {
     siteId: string;
     interval: string;
     dataFetcher: any; // ignore type for now
     columnHeaders: string[];
     loaderUrl: string;
+    onClick?: Function;
 }) => {
     const countsByProperty = dataFetcher.data?.countsByProperty || [];
     const page = dataFetcher.data?.page || 1;
@@ -50,6 +52,7 @@ const ReferrerCard = ({
                     <TableCard
                         countByProperty={countsByProperty}
                         columnHeaders={columnHeaders}
+                        onClick={onClick}
                     />
                     <PaginationButtons
                         page={page}
@@ -62,4 +65,4 @@ const ReferrerCard = ({
     );
 };
 
-export default ReferrerCard;
+export default PaginatedTableCard;

--- a/app/components/PaginatedTableCard.tsx
+++ b/app/components/PaginatedTableCard.tsx
@@ -3,6 +3,7 @@ import TableCard from "~/components/TableCard";
 
 import { Card } from "./ui/card";
 import PaginationButtons from "./PaginationButtons";
+import { SearchFilters } from "~/lib/types";
 
 const PaginatedTableCard = ({
     siteId,
@@ -17,7 +18,7 @@ const PaginatedTableCard = ({
     interval: string;
     dataFetcher: any; // ignore type for now
     columnHeaders: string[];
-    filters?: Record<string, string>;
+    filters?: SearchFilters;
     loaderUrl: string;
     onClick?: (key: string) => void;
 }) => {

--- a/app/components/PaginatedTableCard.tsx
+++ b/app/components/PaginatedTableCard.tsx
@@ -17,38 +17,41 @@ const PaginatedTableCard = ({
     interval: string;
     dataFetcher: any; // ignore type for now
     columnHeaders: string[];
-    filters: Record<string, string>;
+    filters?: Record<string, string>;
     loaderUrl: string;
-    onClick?: Function;
+    onClick?: (key: string) => void;
 }) => {
     const countsByProperty = dataFetcher.data?.countsByProperty || [];
     const page = dataFetcher.data?.page || 1;
 
-    // turn filters into query string
-    const filterString = filters
-        ? Object.entries(filters).map(([key, value]) => `&${key}=${value}`)
-        : "";
+    const loadData = (page: string | undefined = undefined) => {
+        // turn filters into query string
+        const filterString = filters
+            ? Object.entries(filters).map(([key, value]) => `&${key}=${value}`)
+            : "";
+
+        let url = `${loaderUrl}?site=${siteId}&interval=${interval}${filterString}`;
+        if (page) {
+            url += `&page=${page}`;
+        }
+
+        dataFetcher.load(url);
+    };
 
     useEffect(() => {
         if (dataFetcher.state === "idle") {
-            dataFetcher.load(
-                `${loaderUrl}?site=${siteId}&interval=${interval}${filterString}`,
-            );
+            loadData();
         }
     }, []);
 
     useEffect(() => {
         if (dataFetcher.state === "idle") {
-            dataFetcher.load(
-                `${loaderUrl}?site=${siteId}&interval=${interval}${filterString}`,
-            );
+            loadData();
         }
-    }, [siteId, interval]);
+    }, [siteId, interval, filters]);
 
     function handlePagination(page: number) {
-        dataFetcher.load(
-            `${loaderUrl}?site=${siteId}&interval=${interval}&page=${page}${filterString}`,
-        );
+        loadData(page.toString());
     }
 
     const hasMore = countsByProperty.length === 10;

--- a/app/components/SearchFilterBadges.tsx
+++ b/app/components/SearchFilterBadges.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+
+import { SearchFilters } from "~/lib/types";
+
+interface SearchFiltersProps {
+    filters: SearchFilters;
+    onFilterDelete: (key: keyof SearchFilters) => void;
+}
+
+const SearchFilterBadges: React.FC<SearchFiltersProps> = ({
+    filters = {},
+    onFilterDelete,
+}) => {
+    // render each filter as a cancelable pill
+    // when clicked, remove the filter from the list
+    // if no filters are present, don't show anything
+    return (
+        <div className="flex flex-wrap gap-2">
+            {Object.entries(filters).map(([key, value]) => (
+                <div
+                    key={key}
+                    className="bg-primary text-primary-foreground rounded-full px-2 py-1"
+                >
+                    {key}:&quot;{value}&quot;
+                    {/* radix ui cross1 svg */}
+                    <button
+                        onClick={() =>
+                            onFilterDelete(key as keyof SearchFilters)
+                        }
+                        className="ml-2 align-middle"
+                    >
+                        <svg
+                            width="15"
+                            height="15"
+                            viewBox="0 0 15 15"
+                            fill="none"
+                            xmlns="http://www.w3.org/2000/svg"
+                        >
+                            <path
+                                d="M11.7816 4.03157C12.0062 3.80702 12.0062 3.44295 11.7816 3.2184C11.5571 2.99385 11.193 2.99385 10.9685 3.2184L7.50005 6.68682L4.03164 3.2184C3.80708 2.99385 3.44301 2.99385 3.21846 3.2184C2.99391 3.44295 2.99391 3.80702 3.21846 4.03157L6.68688 7.49999L3.21846 10.9684C2.99391 11.193 2.99391 11.557 3.21846 11.7816C3.44301 12.0061 3.80708 12.0061 4.03164 11.7816L7.50005 8.31316L10.9685 11.7816C11.193 12.0061 11.5571 12.0061 11.7816 11.7816C12.0062 11.557 12.0062 11.193 11.7816 10.9684L8.31322 7.49999L11.7816 4.03157Z"
+                                fill="currentColor"
+                                fillRule="evenodd"
+                                clipRule="evenodd"
+                            ></path>
+                        </svg>
+                    </button>
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export default SearchFilterBadges;

--- a/app/components/TableCard.tsx
+++ b/app/components/TableCard.tsx
@@ -58,36 +58,43 @@ export default function TableCard({
                 </TableRow>
             </TableHeader>
             <TableBody>
-                {(countByProperty || []).map((item, key) => (
-                    <TableRow
-                        key={item[0]}
-                        className={`group [&_td]:last:rounded-b-md ${gridCols}`}
-                        width={barChartPercentages[key]}
-                    >
-                        <TableCell className="font-medium min-w-48 break-all">
-                            {onClick ? (
-                                <button
-                                    onClick={() => onClick(item[0] as string)}
-                                    className="hover:underline"
-                                >
-                                    {item[0]}
-                                </button>
-                            ) : (
-                                item[0]
-                            )}
-                        </TableCell>
+                {(countByProperty || []).map((item, index) => {
+                    const label = Array.isArray(item[0]) ? item[0][1] : item[0];
+                    const key = Array.isArray(item[0]) ? item[0][0] : item[0];
 
-                        <TableCell className="text-right min-w-16">
-                            {countFormatter.format(parseInt(item[1], 10))}
-                        </TableCell>
-
-                        {item.length > 2 && item[2] !== undefined && (
-                            <TableCell className="text-right min-w-16">
-                                {countFormatter.format(parseInt(item[2], 10))}
+                    return (
+                        <TableRow
+                            key={item[0]}
+                            className={`group [&_td]:last:rounded-b-md ${gridCols}`}
+                            width={barChartPercentages[index]}
+                        >
+                            <TableCell className="font-medium min-w-48 break-all">
+                                {onClick ? (
+                                    <button
+                                        onClick={() => onClick(key as string)}
+                                        className="hover:underline"
+                                    >
+                                        {label}
+                                    </button>
+                                ) : (
+                                    label
+                                )}
                             </TableCell>
-                        )}
-                    </TableRow>
-                ))}
+
+                            <TableCell className="text-right min-w-16">
+                                {countFormatter.format(parseInt(item[1], 10))}
+                            </TableCell>
+
+                            {item.length > 2 && item[2] !== undefined && (
+                                <TableCell className="text-right min-w-16">
+                                    {countFormatter.format(
+                                        parseInt(item[2], 10),
+                                    )}
+                                </TableCell>
+                            )}
+                        </TableRow>
+                    );
+                })}
             </TableBody>
         </Table>
     );

--- a/app/components/TableCard.tsx
+++ b/app/components/TableCard.tsx
@@ -1,7 +1,3 @@
-import { useSearchParams } from "@remix-run/react";
-
-import PropTypes, { InferProps } from "prop-types";
-
 import {
     Table,
     TableBody,
@@ -32,10 +28,8 @@ export default function TableCard({
 }: {
     countByProperty: CountByProperty;
     columnHeaders: string[];
-    onClick?: Function;
+    onClick?: (key: string) => void;
 }) {
-    const [_, setSearchParams] = useSearchParams();
-
     const barChartPercentages = calculateCountPercentages(countByProperty);
 
     const countFormatter = Intl.NumberFormat("en", { notation: "compact" });
@@ -45,10 +39,6 @@ export default function TableCard({
             ? "grid-cols-[minmax(0,1fr),minmax(0,8ch),minmax(0,8ch)]"
             : "grid-cols-[minmax(0,1fr),minmax(0,8ch)]";
 
-    function handleFilter(value: string | null = "") {
-        if (!value) return;
-        setSearchParams({ filter: value });
-    }
     return (
         <Table>
             <TableHeader>

--- a/app/components/TableCard.tsx
+++ b/app/components/TableCard.tsx
@@ -72,7 +72,7 @@ export default function TableCard({
                                 {onClick ? (
                                     <button
                                         onClick={() => onClick(key as string)}
-                                        className="hover:underline"
+                                        className="hover:underline select-text"
                                     >
                                         {label}
                                     </button>

--- a/app/components/TableCard.tsx
+++ b/app/components/TableCard.tsx
@@ -59,8 +59,13 @@ export default function TableCard({
             </TableHeader>
             <TableBody>
                 {(countByProperty || []).map((item, index) => {
-                    const label = Array.isArray(item[0]) ? item[0][1] : item[0];
-                    const key = Array.isArray(item[0]) ? item[0][0] : item[0];
+                    const desc = item[0];
+
+                    // the description can be either a single string (that is both the key and the label),
+                    // or a tuple of type [key, label]
+                    const [key, label] = Array.isArray(desc)
+                        ? [desc[0], desc[1] || "(none)"]
+                        : [desc, desc || "(none)"];
 
                     return (
                         <TableRow

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -1,0 +1,7 @@
+export interface SearchFilters {
+    path?: string;
+    referrer?: string;
+    deviceModel?: string;
+    country?: string;
+    browserName?: string;
+}

--- a/app/lib/utils.test.ts
+++ b/app/lib/utils.test.ts
@@ -1,0 +1,22 @@
+import { getFiltersFromSearchParams } from "./utils";
+import { describe, test, expect } from "vitest";
+
+// test this getfiltersfromsearchparams function
+describe("getFiltersFromSearchParams", () => {
+    test("it should return an object with the correct keys", () => {
+        const searchParams = new URLSearchParams(
+            "?path=/about&referrer=google.com",
+        );
+        expect(getFiltersFromSearchParams(searchParams)).toEqual({
+            path: "/about",
+            referrer: "google.com",
+        });
+    });
+
+    test("it should ignore keys it doesn't recognize", () => {
+        const searchParams = new URLSearchParams("?unknown=foo&path=/about");
+        expect(getFiltersFromSearchParams(searchParams)).toEqual({
+            path: "/about",
+        });
+    });
+});

--- a/app/lib/utils.test.ts
+++ b/app/lib/utils.test.ts
@@ -5,15 +5,19 @@ import { describe, test, expect } from "vitest";
 describe("getFiltersFromSearchParams", () => {
     test("it should return an object with the correct keys", () => {
         const searchParams = new URLSearchParams(
-            "?path=/about&referrer=google.com",
+            "?path=/about&referrer=google.com&deviceModel=iphone&country=us&browserName=chrome",
         );
         expect(getFiltersFromSearchParams(searchParams)).toEqual({
             path: "/about",
             referrer: "google.com",
+            deviceModel: "iphone",
+            country: "us",
+            browserName: "chrome",
         });
     });
 
     test("it should ignore keys it doesn't recognize", () => {
+        // only path is valid; unknown should be discarded
         const searchParams = new URLSearchParams("?unknown=foo&path=/about");
         expect(getFiltersFromSearchParams(searchParams)).toEqual({
             path: "/about",

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -6,10 +6,26 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export function paramsFromUrl(url: string) {
+    console.log(url);
     const searchParams = new URL(url).searchParams;
     const params: Record<string, string> = {};
     searchParams.forEach((value, key) => {
         params[key] = value;
     });
     return params;
+}
+
+export function getFiltersFromUrl(searchParams: URLSearchParams) {
+    let path;
+    try {
+        path = searchParams.get("path") || "";
+    } catch (err) {
+        path = "";
+    }
+
+    const filters: any = {};
+    if (path) {
+        filters["path"] = path;
+    }
+    return filters;
 }

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -17,9 +17,9 @@ export function paramsFromUrl(url: string) {
 interface SearchFilters {
     path?: string;
     referrer?: string;
-    device?: string;
+    deviceModel?: string;
     country?: string;
-    browser?: string;
+    browserName?: string;
 }
 
 export function getFiltersFromSearchParams(searchParams: URLSearchParams) {
@@ -31,14 +31,14 @@ export function getFiltersFromSearchParams(searchParams: URLSearchParams) {
     if (searchParams.has("referrer")) {
         filters.referrer = searchParams.get("referrer") || "";
     }
-    if (searchParams.has("device")) {
-        filters.device = searchParams.get("device") || "";
+    if (searchParams.has("deviceModel")) {
+        filters.deviceModel = searchParams.get("deviceModel") || "";
     }
     if (searchParams.has("country")) {
         filters.country = searchParams.get("country") || "";
     }
-    if (searchParams.has("browser")) {
-        filters.browser = searchParams.get("browser") || "";
+    if (searchParams.has("browserName")) {
+        filters.browserName = searchParams.get("browserName") || "";
     }
 
     return filters;

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -14,17 +14,32 @@ export function paramsFromUrl(url: string) {
     return params;
 }
 
-export function getFiltersFromUrl(searchParams: URLSearchParams) {
-    let path;
-    try {
-        path = searchParams.get("path") || "";
-    } catch (err) {
-        path = "";
+interface SearchFilters {
+    path?: string;
+    referrer?: string;
+    device?: string;
+    country?: string;
+    browser?: string;
+}
+
+export function getFiltersFromSearchParams(searchParams: URLSearchParams) {
+    const filters: SearchFilters = {};
+
+    if (searchParams.has("path")) {
+        filters.path = searchParams.get("path") || "";
+    }
+    if (searchParams.has("referrer")) {
+        filters.referrer = searchParams.get("referrer") || "";
+    }
+    if (searchParams.has("device")) {
+        filters.device = searchParams.get("device") || "";
+    }
+    if (searchParams.has("country")) {
+        filters.country = searchParams.get("country") || "";
+    }
+    if (searchParams.has("browser")) {
+        filters.browser = searchParams.get("browser") || "";
     }
 
-    const filters: any = {};
-    if (path) {
-        filters["path"] = path;
-    }
     return filters;
 }

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -6,7 +6,6 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export function paramsFromUrl(url: string) {
-    console.log(url);
     const searchParams = new URL(url).searchParams;
     const params: Record<string, string> = {};
     searchParams.forEach((value, key) => {

--- a/app/routes/dashboard.test.tsx
+++ b/app/routes/dashboard.test.tsx
@@ -344,6 +344,9 @@ describe("Dashboard route", () => {
             ["2024-01-18 05:00:00", 0],
         ],
         intervalType: "day",
+        filters: {
+            path: "/lol",
+        },
     };
 
     test("renders with valid data", async () => {

--- a/app/routes/dashboard.test.tsx
+++ b/app/routes/dashboard.test.tsx
@@ -190,6 +190,7 @@ describe("Dashboard route", () => {
             const json = await response.json();
 
             expect(json).toEqual({
+                filters: {},
                 siteId: "test-siteid",
                 sites: ["test-siteid"],
                 views: 6,
@@ -241,6 +242,7 @@ describe("Dashboard route", () => {
             const json = await response.json();
 
             expect(json).toEqual({
+                filters: {},
                 siteId: "",
                 sites: [],
                 views: 0,

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -24,6 +24,7 @@ import { DeviceCard } from "./resources.device";
 import TimeSeriesChart from "~/components/TimeSeriesChart";
 import dayjs from "dayjs";
 import { getFiltersFromSearchParams } from "~/lib/utils";
+import { SearchFilters } from "~/lib/types";
 
 export const meta: MetaFunction = () => {
     return [
@@ -187,10 +188,12 @@ export default function Dashboard() {
 
     const countFormatter = Intl.NumberFormat("en", { notation: "compact" });
 
-    const handleFilterChange = (filters: Record<string, string>) => {
+    const handleFilterChange = (filters: SearchFilters) => {
         setSearchParams((prev) => {
             for (const key in filters) {
-                prev.set(key, filters[key]);
+                if (Object.hasOwnProperty.call(filters, key)) {
+                    prev.set(key, (filters as any)[key]);
+                }
             }
             return prev;
         });

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -214,7 +214,7 @@ export default function Dashboard() {
     return (
         <div style={{ fontFamily: "system-ui, sans-serif", lineHeight: "1.8" }}>
             <div className="w-full mb-4 flex gap-4 flex-wrap">
-                <div className="md:basis-1/5-gap-4 basis-1/2-gap-4">
+                <div className="lg:basis-1/5-gap-4 sm:basis-1/4-gap-4 basis-1/2-gap-4">
                     <Select
                         defaultValue={data.siteId}
                         onValueChange={(site) => changeSite(site)}
@@ -236,7 +236,7 @@ export default function Dashboard() {
                     </Select>
                 </div>
 
-                <div className="md:basis-1/5-gap-4 basis-1/2-gap-4">
+                <div className="lg:basis-1/5-gap-4 sm:basis-1/4-gap-4 basis-1/2-gap-4">
                     <Select
                         defaultValue={data.interval}
                         onValueChange={(interval) => changeInterval(interval)}
@@ -254,7 +254,7 @@ export default function Dashboard() {
                     </Select>
                 </div>
 
-                <div className="md:basis-1/2-gap-4 basis-full">
+                <div className="basis-auto">
                     <SearchFilterBadges
                         filters={data.filters}
                         onFilterDelete={handleFilterDelete}

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -165,9 +165,13 @@ export default function Dashboard() {
     const loading = navigation.state === "loading";
 
     function changeSite(site: string) {
-        setSearchParams((prev) => {
-            prev.set("site", site);
-            return prev;
+        // intentionally not updating prev params; don't want search
+        // filters (e.g. referrer, path) to persist
+
+        // TODO: might revisit if this is considered unexpected behavior
+        setSearchParams({
+            site,
+            interval: data.interval,
         });
     }
 

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -213,8 +213,8 @@ export default function Dashboard() {
 
     return (
         <div style={{ fontFamily: "system-ui, sans-serif", lineHeight: "1.8" }}>
-            <div className="w-full mb-4 flex gap-4">
-                <div className="w-1/2 sm:w-1/3 md:w-1/5">
+            <div className="w-full mb-4 flex gap-4 flex-wrap">
+                <div className="md:basis-1/5-gap-4 basis-1/2-gap-4">
                     <Select
                         defaultValue={data.siteId}
                         onValueChange={(site) => changeSite(site)}
@@ -236,7 +236,7 @@ export default function Dashboard() {
                     </Select>
                 </div>
 
-                <div className="w-1/2 sm:w-1/3 md:w-1/5">
+                <div className="md:basis-1/5-gap-4 basis-1/2-gap-4">
                     <Select
                         defaultValue={data.interval}
                         onValueChange={(interval) => changeInterval(interval)}
@@ -254,7 +254,7 @@ export default function Dashboard() {
                     </Select>
                 </div>
 
-                <div>
+                <div className="md:basis-1/2-gap-4 basis-full">
                     <SearchFilterBadges
                         filters={data.filters}
                         onFilterDelete={handleFilterDelete}

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -72,7 +72,6 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
 
     const filters = getFiltersFromSearchParams(url.searchParams);
 
-    console.log(filters);
     const tz = context.cloudflare.cf.timezone as string;
 
     // initiate requests to AE in parallel
@@ -303,14 +302,20 @@ export default function Dashboard() {
                     <BrowserCard
                         siteId={data.siteId}
                         interval={data.interval}
+                        filters={data.filters}
                     />
 
                     <CountryCard
                         siteId={data.siteId}
                         interval={data.interval}
+                        filters={data.filters}
                     />
 
-                    <DeviceCard siteId={data.siteId} interval={data.interval} />
+                    <DeviceCard
+                        siteId={data.siteId}
+                        interval={data.interval}
+                        filters={data.filters}
+                    />
                 </div>
             </div>
         </div>

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -25,6 +25,7 @@ import TimeSeriesChart from "~/components/TimeSeriesChart";
 import dayjs from "dayjs";
 import { getFiltersFromSearchParams } from "~/lib/utils";
 import { SearchFilters } from "~/lib/types";
+import SearchFilterBadges from "~/components/SearchFilterBadges";
 
 export const meta: MetaFunction = () => {
     return [
@@ -202,6 +203,14 @@ export default function Dashboard() {
             return prev;
         });
     };
+
+    const handleFilterDelete = (key: string) => {
+        setSearchParams((prev) => {
+            prev.delete(key);
+            return prev;
+        });
+    };
+
     return (
         <div style={{ fontFamily: "system-ui, sans-serif", lineHeight: "1.8" }}>
             <div className="w-full mb-4 flex gap-4">
@@ -243,6 +252,13 @@ export default function Dashboard() {
                             <SelectItem value="90d">90 days</SelectItem>
                         </SelectContent>
                     </Select>
+                </div>
+
+                <div>
+                    <SearchFilterBadges
+                        filters={data.filters}
+                        onFilterDelete={handleFilterDelete}
+                    />
                 </div>
             </div>
 

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -303,18 +303,21 @@ export default function Dashboard() {
                         siteId={data.siteId}
                         interval={data.interval}
                         filters={data.filters}
+                        onFilterChange={handleFilterChange}
                     />
 
                     <CountryCard
                         siteId={data.siteId}
                         interval={data.interval}
                         filters={data.filters}
+                        onFilterChange={handleFilterChange}
                     />
 
                     <DeviceCard
                         siteId={data.siteId}
                         interval={data.interval}
                         filters={data.filters}
+                        onFilterChange={handleFilterChange}
                     />
                 </div>
             </div>

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -155,6 +155,7 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
             intervalType,
             interval,
             tz,
+            filters,
         };
     } catch (err) {
         console.error(err);
@@ -285,7 +286,11 @@ export default function Dashboard() {
                     </Card>
                 </div>
                 <div className="grid md:grid-cols-2 gap-4 mb-4">
-                    <PathsCard siteId={data.siteId} interval={data.interval} />
+                    <PathsCard
+                        siteId={data.siteId}
+                        interval={data.interval}
+                        filters={data.filters}
+                    />
                     <ReferrerCard
                         siteId={data.siteId}
                         interval={data.interval}

--- a/app/routes/resources.browser.tsx
+++ b/app/routes/resources.browser.tsx
@@ -5,6 +5,7 @@ import { json } from "@remix-run/cloudflare";
 
 import { getFiltersFromSearchParams, paramsFromUrl } from "~/lib/utils";
 import PaginatedTableCard from "~/components/PaginatedTableCard";
+import { SearchFilters } from "~/lib/types";
 
 export async function loader({ context, request }: LoaderFunctionArgs) {
     const { analyticsEngine } = context;
@@ -35,8 +36,8 @@ export const BrowserCard = ({
 }: {
     siteId: string;
     interval: string;
-    filters: Record<string, string>;
-    onFilterChange: (filters: Record<string, string>) => void;
+    filters: SearchFilters;
+    onFilterChange: (filters: SearchFilters) => void;
 }) => {
     return (
         <PaginatedTableCard

--- a/app/routes/resources.browser.tsx
+++ b/app/routes/resources.browser.tsx
@@ -31,10 +31,12 @@ export const BrowserCard = ({
     siteId,
     interval,
     filters,
+    onFilterChange,
 }: {
     siteId: string;
     interval: string;
     filters: Record<string, string>;
+    onFilterChange: (filters: Record<string, string>) => void;
 }) => {
     return (
         <PaginatedTableCard
@@ -44,6 +46,9 @@ export const BrowserCard = ({
             dataFetcher={useFetcher<typeof loader>()}
             loaderUrl="/resources/browser"
             filters={filters}
+            onClick={(browserName) =>
+                onFilterChange({ ...filters, browserName })
+            }
         />
     );
 };

--- a/app/routes/resources.country.tsx
+++ b/app/routes/resources.country.tsx
@@ -9,7 +9,7 @@ import { SearchFilters } from "~/lib/types";
 
 function convertCountryCodesToNames(
     countByCountry: [string, number][],
-): [string, number][] {
+): [[string, string], number][] {
     const regionNames = new Intl.DisplayNames(["en"], { type: "region" });
     return countByCountry.map((countByBrowserRow) => {
         let countryName;
@@ -22,7 +22,7 @@ function convertCountryCodesToNames(
             countryName = "(unknown)";
         }
         const count = countByBrowserRow[1];
-        return [countryName, count];
+        return [[countByBrowserRow[0], countryName], count];
     });
 }
 

--- a/app/routes/resources.country.tsx
+++ b/app/routes/resources.country.tsx
@@ -34,7 +34,6 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     const url = new URL(request.url);
     const filters = getFiltersFromSearchParams(new URL(url).searchParams);
 
-    console.log("filters", filters);
     const countByCountry = await analyticsEngine.getCountByCountry(
         site,
         interval,
@@ -59,10 +58,12 @@ export const CountryCard = ({
     siteId,
     interval,
     filters,
+    onFilterChange,
 }: {
     siteId: string;
     interval: string;
     filters: Record<string, string>;
+    onFilterChange: (filters: Record<string, string>) => void;
 }) => {
     return (
         <PaginatedTableCard
@@ -72,6 +73,7 @@ export const CountryCard = ({
             dataFetcher={useFetcher<typeof loader>()}
             loaderUrl="/resources/country"
             filters={filters}
+            onClick={(country) => onFilterChange({ ...filters, country })}
         />
     );
 };

--- a/app/routes/resources.country.tsx
+++ b/app/routes/resources.country.tsx
@@ -3,7 +3,7 @@ import { useFetcher } from "@remix-run/react";
 import type { LoaderFunctionArgs } from "@remix-run/cloudflare";
 import { json } from "@remix-run/cloudflare";
 
-import { paramsFromUrl } from "~/lib/utils";
+import { getFiltersFromSearchParams, paramsFromUrl } from "~/lib/utils";
 import PaginatedTableCard from "~/components/PaginatedTableCard";
 
 function convertCountryCodesToNames(
@@ -31,10 +31,15 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     const { interval, site, page = 1 } = paramsFromUrl(request.url);
     const tz = context.cloudflare.cf.timezone as string;
 
+    const url = new URL(request.url);
+    const filters = getFiltersFromSearchParams(new URL(url).searchParams);
+
+    console.log("filters", filters);
     const countByCountry = await analyticsEngine.getCountByCountry(
         site,
         interval,
         tz,
+        filters,
         Number(page),
     );
 
@@ -53,9 +58,11 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
 export const CountryCard = ({
     siteId,
     interval,
+    filters,
 }: {
     siteId: string;
     interval: string;
+    filters: Record<string, string>;
 }) => {
     return (
         <PaginatedTableCard
@@ -64,6 +71,7 @@ export const CountryCard = ({
             columnHeaders={["Country", "Visitors"]}
             dataFetcher={useFetcher<typeof loader>()}
             loaderUrl="/resources/country"
+            filters={filters}
         />
     );
 };

--- a/app/routes/resources.country.tsx
+++ b/app/routes/resources.country.tsx
@@ -5,6 +5,7 @@ import { json } from "@remix-run/cloudflare";
 
 import { getFiltersFromSearchParams, paramsFromUrl } from "~/lib/utils";
 import PaginatedTableCard from "~/components/PaginatedTableCard";
+import { SearchFilters } from "~/lib/types";
 
 function convertCountryCodesToNames(
     countByCountry: [string, number][],
@@ -62,8 +63,8 @@ export const CountryCard = ({
 }: {
     siteId: string;
     interval: string;
-    filters: Record<string, string>;
-    onFilterChange: (filters: Record<string, string>) => void;
+    filters: SearchFilters;
+    onFilterChange: (filters: SearchFilters) => void;
 }) => {
     return (
         <PaginatedTableCard

--- a/app/routes/resources.device.tsx
+++ b/app/routes/resources.device.tsx
@@ -5,6 +5,7 @@ import { json } from "@remix-run/cloudflare";
 
 import { getFiltersFromSearchParams, paramsFromUrl } from "~/lib/utils";
 import PaginatedTableCard from "~/components/PaginatedTableCard";
+import { SearchFilters } from "~/lib/types";
 
 export async function loader({ context, request }: LoaderFunctionArgs) {
     const { analyticsEngine } = context;
@@ -35,8 +36,8 @@ export const DeviceCard = ({
 }: {
     siteId: string;
     interval: string;
-    filters: Record<string, string>;
-    onFilterChange: (filters: Record<string, string>) => void;
+    filters: SearchFilters;
+    onFilterChange: (filters: SearchFilters) => void;
 }) => {
     return (
         <PaginatedTableCard

--- a/app/routes/resources.device.tsx
+++ b/app/routes/resources.device.tsx
@@ -3,7 +3,7 @@ import { useFetcher } from "@remix-run/react";
 import type { LoaderFunctionArgs } from "@remix-run/cloudflare";
 import { json } from "@remix-run/cloudflare";
 
-import { paramsFromUrl } from "~/lib/utils";
+import { getFiltersFromSearchParams, paramsFromUrl } from "~/lib/utils";
 import PaginatedTableCard from "~/components/PaginatedTableCard";
 
 export async function loader({ context, request }: LoaderFunctionArgs) {
@@ -12,11 +12,15 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     const { interval, site, page = 1 } = paramsFromUrl(request.url);
     const tz = context.cloudflare.cf.timezone as string;
 
+    const url = new URL(request.url);
+    const filters = getFiltersFromSearchParams(new URL(url).searchParams);
+
     return json({
         countsByProperty: await analyticsEngine.getCountByDevice(
             site,
             interval,
             tz,
+            filters,
             Number(page),
         ),
         page: Number(page),
@@ -26,9 +30,11 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
 export const DeviceCard = ({
     siteId,
     interval,
+    filters,
 }: {
     siteId: string;
     interval: string;
+    filters: Record<string, string>;
 }) => {
     return (
         <PaginatedTableCard
@@ -37,6 +43,7 @@ export const DeviceCard = ({
             columnHeaders={["Device", "Visitors"]}
             dataFetcher={useFetcher<typeof loader>()}
             loaderUrl="/resources/device"
+            filters={filters}
         />
     );
 };

--- a/app/routes/resources.device.tsx
+++ b/app/routes/resources.device.tsx
@@ -31,10 +31,12 @@ export const DeviceCard = ({
     siteId,
     interval,
     filters,
+    onFilterChange,
 }: {
     siteId: string;
     interval: string;
     filters: Record<string, string>;
+    onFilterChange: (filters: Record<string, string>) => void;
 }) => {
     return (
         <PaginatedTableCard
@@ -44,6 +46,9 @@ export const DeviceCard = ({
             dataFetcher={useFetcher<typeof loader>()}
             loaderUrl="/resources/device"
             filters={filters}
+            onClick={(deviceModel) =>
+                onFilterChange({ ...filters, deviceModel })
+            }
         />
     );
 };

--- a/app/routes/resources.paths.tsx
+++ b/app/routes/resources.paths.tsx
@@ -1,10 +1,10 @@
-import { useFetcher, useSearchParams, useNavigate } from "@remix-run/react";
+import { useFetcher } from "@remix-run/react";
 
 import type { LoaderFunctionArgs } from "@remix-run/cloudflare";
 import { json } from "@remix-run/cloudflare";
 
 import {
-    getFiltersFromUrl as getFiltersFromSearchParams,
+    getFiltersFromSearchParams as getFiltersFromSearchParams,
     paramsFromUrl,
 } from "~/lib/utils";
 import PaginatedTableCard from "~/components/PaginatedTableCard";
@@ -34,22 +34,13 @@ export const PathsCard = ({
     siteId,
     interval,
     filters,
+    onFilterChange,
 }: {
     siteId: string;
     interval: string;
     filters: Record<string, string>;
+    onFilterChange: (filters: Record<string, string>) => void;
 }) => {
-    const [, setSearchParams] = useSearchParams();
-    const navigate = useNavigate();
-
-    function handleClick(path: string) {
-        setSearchParams((prev) => {
-            prev.set("path", path);
-            return prev;
-        });
-        navigate(".", { replace: true });
-    }
-
     return (
         <PaginatedTableCard
             siteId={siteId}
@@ -58,7 +49,7 @@ export const PathsCard = ({
             dataFetcher={useFetcher<typeof loader>()}
             filters={filters}
             loaderUrl="/resources/paths"
-            onClick={handleClick}
+            onClick={(path) => onFilterChange({ ...filters, path })}
         />
     );
 };

--- a/app/routes/resources.paths.tsx
+++ b/app/routes/resources.paths.tsx
@@ -8,6 +8,7 @@ import {
     paramsFromUrl,
 } from "~/lib/utils";
 import PaginatedTableCard from "~/components/PaginatedTableCard";
+import { SearchFilters } from "~/lib/types";
 
 export async function loader({ context, request }: LoaderFunctionArgs) {
     const { analyticsEngine } = context;
@@ -38,8 +39,8 @@ export const PathsCard = ({
 }: {
     siteId: string;
     interval: string;
-    filters: Record<string, string>;
-    onFilterChange: (filters: Record<string, string>) => void;
+    filters: SearchFilters;
+    onFilterChange: (filters: SearchFilters) => void;
 }) => {
     return (
         <PaginatedTableCard

--- a/app/routes/resources.paths.tsx
+++ b/app/routes/resources.paths.tsx
@@ -1,4 +1,4 @@
-import { useFetcher } from "@remix-run/react";
+import { useFetcher, useSearchParams } from "@remix-run/react";
 
 import type { LoaderFunctionArgs } from "@remix-run/cloudflare";
 import { json } from "@remix-run/cloudflare";
@@ -30,6 +30,13 @@ export const PathsCard = ({
     siteId: string;
     interval: string;
 }) => {
+    const [searchParams, setSearchParams] = useSearchParams();
+    function handleClick(path: string) {
+        setSearchParams((prev) => {
+            prev.set("path", path);
+            return prev;
+        });
+    }
     return (
         <PaginatedTableCard
             siteId={siteId}
@@ -37,6 +44,7 @@ export const PathsCard = ({
             columnHeaders={["Path", "Visitors", "Views"]}
             dataFetcher={useFetcher<typeof loader>()}
             loaderUrl="/resources/paths"
+            onClick={handleClick}
         />
     );
 };

--- a/app/routes/resources.paths.tsx
+++ b/app/routes/resources.paths.tsx
@@ -18,7 +18,6 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     const url = new URL(request.url);
     const filters = getFiltersFromSearchParams(new URL(url).searchParams);
 
-    console.log(filters, site);
     return json({
         countsByProperty: await analyticsEngine.getCountByPath(
             site,
@@ -34,22 +33,22 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
 export const PathsCard = ({
     siteId,
     interval,
+    filters,
 }: {
     siteId: string;
     interval: string;
+    filters: Record<string, string>;
 }) => {
-    const [searchParams, setSearchParams] = useSearchParams();
+    const [, setSearchParams] = useSearchParams();
+    const navigate = useNavigate();
+
     function handleClick(path: string) {
         setSearchParams((prev) => {
             prev.set("path", path);
             return prev;
         });
-        const navigate = useNavigate();
         navigate(".", { replace: true });
     }
-
-    // convert searchParams to Record
-    const filters = getFiltersFromSearchParams(searchParams);
 
     return (
         <PaginatedTableCard

--- a/app/routes/resources.referrer.tsx
+++ b/app/routes/resources.referrer.tsx
@@ -17,7 +17,6 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     const url = new URL(request.url);
     const filters = getFiltersFromSearchParams(new URL(url).searchParams);
 
-    console.log("filters", filters);
     return json({
         countsByProperty: await analyticsEngine.getCountByReferrer(
             site,

--- a/app/routes/resources.referrer.tsx
+++ b/app/routes/resources.referrer.tsx
@@ -6,17 +6,24 @@ import { json } from "@remix-run/cloudflare";
 import { paramsFromUrl } from "~/lib/utils";
 import PaginatedTableCard from "~/components/PaginatedTableCard";
 
+import { getFiltersFromSearchParams } from "~/lib/utils";
+
 export async function loader({ context, request }: LoaderFunctionArgs) {
     const { analyticsEngine } = context;
 
     const { interval, site, page = 1 } = paramsFromUrl(request.url);
     const tz = context.cloudflare.cf.timezone as string;
 
+    const url = new URL(request.url);
+    const filters = getFiltersFromSearchParams(new URL(url).searchParams);
+
+    console.log("filters", filters);
     return json({
         countsByProperty: await analyticsEngine.getCountByReferrer(
             site,
             interval,
             tz,
+            filters,
             Number(page),
         ),
         page: Number(page),
@@ -26,9 +33,13 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
 export const ReferrerCard = ({
     siteId,
     interval,
+    filters,
+    onFilterChange,
 }: {
     siteId: string;
     interval: string;
+    filters: Record<string, string>;
+    onFilterChange: (filters: Record<string, string>) => void;
 }) => {
     return (
         <PaginatedTableCard
@@ -37,6 +48,8 @@ export const ReferrerCard = ({
             columnHeaders={["Referrer", "Visitors"]}
             dataFetcher={useFetcher<typeof loader>()}
             loaderUrl="/resources/referrer"
+            filters={filters}
+            onClick={(referrer) => onFilterChange({ ...filters, referrer })}
         />
     );
 };

--- a/app/routes/resources.referrer.tsx
+++ b/app/routes/resources.referrer.tsx
@@ -7,6 +7,7 @@ import { paramsFromUrl } from "~/lib/utils";
 import PaginatedTableCard from "~/components/PaginatedTableCard";
 
 import { getFiltersFromSearchParams } from "~/lib/utils";
+import { SearchFilters } from "~/lib/types";
 
 export async function loader({ context, request }: LoaderFunctionArgs) {
     const { analyticsEngine } = context;
@@ -37,8 +38,8 @@ export const ReferrerCard = ({
 }: {
     siteId: string;
     interval: string;
-    filters: Record<string, string>;
-    onFilterChange: (filters: Record<string, string>) => void;
+    filters: SearchFilters;
+    onFilterChange: (filters: SearchFilters) => void;
 }) => {
     return (
         <PaginatedTableCard

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,6 +20,7 @@ module.exports = {
             flexBasis: {
                 /* dashboard layout */
                 "1/2-gap-4": "calc(50% - (1/2 * 1rem))",
+                "1/3-gap-4": "calc(33.333333% - (1/3 * 1rem))",
                 "1/4-gap-4": "calc(25% - (1/4 * 1rem))",
                 "1/5-gap-4": "calc(20% - (1/5 * 1rem))",
             },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,6 +17,12 @@ module.exports = {
             },
         },
         extend: {
+            flexBasis: {
+                /* dashboard layout */
+                "1/2-gap-4": "calc(50% - (1/2 * 1rem))",
+                "1/4-gap-4": "calc(25% - (1/4 * 1rem))",
+                "1/5-gap-4": "calc(20% - (1/5 * 1rem))",
+            },
             colors: {
                 border: "hsl(var(--border))",
                 input: "hsl(var(--input))",


### PR DESCRIPTION
_Note this targets the `v2` branch_

Now if users click a row within a table card, the full data set will be filtered by that selection.

For example, if in the "Paths" card, you click a given path (e.g. "/dashboard"), the dataset will reload filering on `path"=/dashboard"`. This means every figure – the top-level numbers, the chart, and all the table cards – will respect that filter.

You can also combine multiple filters (e.g. by referrer _and_ device).

---

**Still left to do:**
* [x] Filter by Country don't work yet (needs to filter on the underlying country code, not the label)
* [x] Need to show the current filters somewhere (e.g. cancel-able pills at the top of the page)
* [x] Automated tests
* [x] Polish
* [x] Better types

https://github.com/user-attachments/assets/e50a3abf-0673-4f47-ac49-3d70f328f8ce

