### PR TITLE
Tighten UI density

### DIFF
--- a/app/components/ui/table.tsx
+++ b/app/components/ui/table.tsx
@@ -88,7 +88,7 @@ const TableHead = React.forwardRef<
     <div
         ref={ref}
         className={cn(
-            "h-12 p-4 text-left align-middle font-medium [&:has([role=checkbox])]:pr-0",
+            "h-12 p-3 text-left align-middle font-medium [&:has([role=checkbox])]:pr-0",
             className,
         )}
         {...props}
@@ -103,7 +103,7 @@ const TableCell = React.forwardRef<
     <div
         ref={ref}
         className={cn(
-            "p-4 align-middle [&:has([role=checkbox])]:pr-0",
+            "p-3 align-middle [&:has([role=checkbox])]:pr-0",
             className,
         )}
         {...props}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -74,7 +74,7 @@ export const Layout = ({ children = [] }: { children: React.ReactNode }) => {
                 <Links />
             </head>
             <body>
-                <div className="container mx-auto mt-4">{children}</div>
+                <div className="container mx-auto">{children}</div>
                 <ScrollRestoration />
                 <Scripts />
                 <script
@@ -91,31 +91,31 @@ export const Layout = ({ children = [] }: { children: React.ReactNode }) => {
 export default function App() {
     const data = useLoaderData<typeof loader>();
     return (
-        <div>
-            <header className="border-b-2 mb-12 py-4">
+        <div className="mt-4">
+            <header className="border-b-2 mb-8 py-2">
                 <nav className="flex justify-between items-center">
                     <div className="flex items-center">
-                        <a href="/" className="text-xl sm:text-2xl font-bold">
+                        <a href="/" className="text-lg font-bold">
                             Counterscale
                         </a>
                         <img
-                            className="w-6 sm:w-8 ml-1"
+                            className="w-6 ml-1"
                             src="/favicon.png"
                             alt="Counterscale Icon"
                         />
                     </div>
-                    <div className="flex items-center font-small font-medium text-md sm:text-lg">
+                    <div className="flex items-center font-small font-medium text-md">
                         <a href="/dashboard">Dashboard</a>
                         <a
                             href="/admin-redirect"
                             target="_blank"
-                            className="hidden sm:inline-block ml-2 sm:ml-4"
+                            className="hidden sm:inline-block ml-2"
                         >
                             Admin
                         </a>
                         <a
                             href="https://github.com/benvinegar/counterscale"
-                            className="w-8 ml-2 sm:ml-4"
+                            className="w-6 ml-2"
                         >
                             <img
                                 src="/github-mark.svg"

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -236,7 +236,7 @@ export default function Dashboard() {
                     </Select>
                 </div>
 
-                <div className="lg:basis-1/5-gap-4 sm:basis-1/4-gap-4 basis-1/2-gap-4">
+                <div className="lg:basis-1/6-gap-4 sm:basis-1/5-gap-4 basis-1/3-gap-4">
                     <Select
                         defaultValue={data.interval}
                         onValueChange={(interval) => changeInterval(interval)}
@@ -265,18 +265,16 @@ export default function Dashboard() {
             <div className="transition" style={{ opacity: loading ? 0.6 : 1 }}>
                 <div className="w-full mb-4">
                     <Card>
-                        <CardContent className="pt-6">
+                        <div className="p-4 pl-6">
                             <div className="grid grid-cols-3 gap-10 items-end">
                                 <div>
-                                    <div className="text-sm sm:text-lg">
-                                        Views
-                                    </div>
+                                    <div className="text-md">Views</div>
                                     <div className="text-4xl">
                                         {countFormatter.format(data.views)}
                                     </div>
                                 </div>
                                 <div>
-                                    <div className="text-sm sm:text-lg">
+                                    <div className="text-md sm:text-lg">
                                         Visits
                                     </div>
                                     <div className="text-4xl">
@@ -284,7 +282,7 @@ export default function Dashboard() {
                                     </div>
                                 </div>
                                 <div>
-                                    <div className="text-sm sm:text-lg">
+                                    <div className="text-md sm:text-lg">
                                         Visitors
                                     </div>
                                     <div className="text-4xl">
@@ -292,13 +290,13 @@ export default function Dashboard() {
                                     </div>
                                 </div>
                             </div>
-                        </CardContent>
+                        </div>
                     </Card>
                 </div>
                 <div className="w-full mb-4">
                     <Card>
                         <CardContent>
-                            <div className="h-80 pt-6 -m-4 -ml-8 sm:m-0">
+                            <div className="h-72 pt-6 -m-4 -ml-8 sm:m-0">
                                 <TimeSeriesChart
                                     data={chartData}
                                     intervalType={data.intervalType}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,6 +23,7 @@ module.exports = {
                 "1/3-gap-4": "calc(33.333333% - (1/3 * 1rem))",
                 "1/4-gap-4": "calc(25% - (1/4 * 1rem))",
                 "1/5-gap-4": "calc(20% - (1/5 * 1rem))",
+                "1/6-gap-4": "calc(16.666667% - (1/6 * 1rem))",
             },
             colors: {
                 border: "hsl(var(--border))",


### PR DESCRIPTION
I've been finding that Counterscale's UI was just a little too "chunky" (lots of padding everywhere), which made viewing the app on a 14" MBP pretty challenging.

This PR attempts to reduce padding and text size around the app to make things a little more appealing:

* Reduce padding and text size of header (the row with "Counterscale")
* Reduce the height of the chart by 10%
* Reduce table padding from 3rem to 2rem

On my 14" MBP, after these changes, I can now see about 4.5 rows of table data (e.g. counts by path or referrer), whereas it was only 2 before.

Before:
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/c8b709f3-a10b-4b4f-b3d8-81abaa622d1e">

After:
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/31cadaa2-7a7f-41eb-a1db-857a96408634">
