### PR TITLE
Refactor data fetching to use browser timezone, remove server rendering

### DIFF
--- a/app/analytics/query.ts
+++ b/app/analytics/query.ts
@@ -600,15 +600,12 @@ export class AnalyticsEngineAPI {
         );
     }
 
-    async getSitesOrderedByHits(interval: string, tz?: string, limit?: number) {
+    async getSitesOrderedByHits(interval: string, limit?: number) {
         // defaults to 1 day if not specified
 
         limit = limit || 10;
 
-        const { startIntervalSql, endIntervalSql } = intervalToSql(
-            interval,
-            tz,
-        );
+        const { startIntervalSql, endIntervalSql } = intervalToSql(interval);
 
         const query = `
             SELECT SUM(_sample_interval) as count,

--- a/app/components/PaginatedTableCard.tsx
+++ b/app/components/PaginatedTableCard.tsx
@@ -37,7 +37,7 @@ const PaginatedTableCard = ({
                   .join("")
             : "";
 
-        let url = `${loaderUrl}?site=${siteId}&interval=${interval}${filterString}`;
+        let url = `${loaderUrl}?site=${siteId}&interval=${interval}&timezone=${timezone}${filterString}`;
         if (page) {
             url += `&page=${page}`;
         }

--- a/app/components/PaginatedTableCard.tsx
+++ b/app/components/PaginatedTableCard.tsx
@@ -5,6 +5,17 @@ import { Card } from "./ui/card";
 import PaginationButtons from "./PaginationButtons";
 import { SearchFilters } from "~/lib/types";
 
+interface PaginatedTableCardProps {
+    siteId: string;
+    interval: string;
+    dataFetcher: any;
+    columnHeaders: string[];
+    filters?: SearchFilters;
+    loaderUrl: string;
+    onClick?: (key: string) => void;
+    timezone?: string;
+}
+
 const PaginatedTableCard = ({
     siteId,
     interval,
@@ -13,15 +24,8 @@ const PaginatedTableCard = ({
     filters,
     loaderUrl,
     onClick,
-}: {
-    siteId: string;
-    interval: string;
-    dataFetcher: any; // ignore type for now
-    columnHeaders: string[];
-    filters?: SearchFilters;
-    loaderUrl: string;
-    onClick?: (key: string) => void;
-}) => {
+    timezone,
+}: PaginatedTableCardProps) => {
     const countsByProperty = dataFetcher.data?.countsByProperty || [];
     const page = dataFetcher.data?.page || 1;
 

--- a/app/components/TimeSeriesChart.tsx
+++ b/app/components/TimeSeriesChart.tsx
@@ -13,6 +13,7 @@ import {
 export default function TimeSeriesChart({
     data,
     intervalType,
+    timezone,
 }: InferProps<typeof TimeSeriesChart.propTypes>) {
     // chart doesn't really work no data points, so just bail out
     if (data.length === 0) {
@@ -51,13 +52,15 @@ export default function TimeSeriesChart({
         // convert from utc to local time
         dateObj.setMinutes(dateObj.getMinutes() - dateObj.getTimezoneOffset());
 
-        return dateObj.toLocaleString("en-us", {
-            weekday: "short",
-            month: "short",
-            day: "numeric",
-            hour: "numeric",
-            minute: "numeric",
-        });
+        return (
+            dateObj.toLocaleString("en-us", {
+                weekday: "short",
+                month: "short",
+                day: "numeric",
+                hour: "numeric",
+                minute: "numeric",
+            }) + ` ${timezone}`
+        );
     }
 
     return (
@@ -97,4 +100,5 @@ TimeSeriesChart.propTypes = {
         }).isRequired,
     ).isRequired,
     intervalType: PropTypes.string,
+    timezone: PropTypes.string,
 };

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -1,5 +1,11 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs));
@@ -42,4 +48,63 @@ export function getFiltersFromSearchParams(searchParams: URLSearchParams) {
     }
 
     return filters;
+}
+
+export function getUserTimezone(): string {
+    try {
+        return Intl.DateTimeFormat().resolvedOptions().timeZone;
+    } catch (e) {
+        // Fallback to UTC if browser doesn't support Intl API
+        return "UTC";
+    }
+}
+
+export function getIntervalType(interval: string): "DAY" | "HOUR" {
+    switch (interval) {
+        case "today":
+        case "yesterday":
+        case "1d":
+            return "HOUR";
+        case "7d":
+        case "30d":
+        case "90d":
+            return "DAY";
+        default:
+            return "DAY";
+    }
+}
+
+export function getDateTimeRange(interval: string, tz: string) {
+    let localDateTime = dayjs().utc();
+    let localEndDateTime: dayjs.Dayjs | undefined;
+
+    if (interval === "today") {
+        localDateTime = localDateTime.tz(tz).startOf("day");
+    } else if (interval === "yesterday") {
+        localDateTime = localDateTime.tz(tz).startOf("day").subtract(1, "day");
+        localEndDateTime = localDateTime.endOf("day").add(2, "ms");
+    } else {
+        const daysAgo = Number(interval.split("d")[0]);
+        const intervalType = getIntervalType(interval);
+
+        if (intervalType === "DAY") {
+            localDateTime = localDateTime
+                .subtract(daysAgo, "day")
+                .tz(tz)
+                .startOf("day");
+        } else if (intervalType === "HOUR") {
+            localDateTime = localDateTime
+                .subtract(daysAgo, "day")
+                .startOf("hour");
+        }
+    }
+
+    if (!localEndDateTime) {
+        localEndDateTime = dayjs().utc().tz(tz);
+    }
+
+    return {
+        startDate: localDateTime.toDate(),
+        endDate: localEndDateTime.toDate(),
+    };
 }

--- a/app/routes/__tests__/dashboard.test.tsx
+++ b/app/routes/__tests__/dashboard.test.tsx
@@ -115,24 +115,6 @@ describe("Dashboard route", () => {
                 }),
             );
 
-            // response for get counts
-            fetch.mockResolvedValueOnce(
-                createFetchResponse({
-                    data: [
-                        { isVisit: 1, isVisitor: 1, count: 1 },
-                        { isVisit: 1, isVisitor: 0, count: 2 },
-                        { isVisit: 0, isVisitor: 0, count: 3 },
-                    ],
-                }),
-            );
-
-            // response for getViewsGroupedByInterval
-            fetch.mockResolvedValueOnce(
-                createFetchResponse({
-                    data: [{ bucket: "2024-01-11 05:00:00", count: 4 }],
-                }),
-            );
-
             vi.setSystemTime(new Date("2024-01-18T09:33:02").getTime());
 
             const response = await loader({
@@ -149,19 +131,6 @@ describe("Dashboard route", () => {
                 filters: {},
                 siteId: "test-siteid",
                 sites: ["test-siteid"],
-                views: 6,
-                visits: 3,
-                visitors: 1,
-                viewsGroupedByInterval: [
-                    ["2024-01-11 05:00:00", 4],
-                    ["2024-01-12 05:00:00", 0],
-                    ["2024-01-13 05:00:00", 0],
-                    ["2024-01-14 05:00:00", 0],
-                    ["2024-01-15 05:00:00", 0],
-                    ["2024-01-16 05:00:00", 0],
-                    ["2024-01-17 05:00:00", 0],
-                    ["2024-01-18 05:00:00", 0],
-                ],
                 intervalType: "DAY",
                 interval: "7d",
             });
@@ -188,19 +157,6 @@ describe("Dashboard route", () => {
                 filters: {},
                 siteId: "",
                 sites: [],
-                views: 0,
-                visits: 0,
-                visitors: 0,
-                viewsGroupedByInterval: [
-                    ["2024-01-11 05:00:00", 0],
-                    ["2024-01-12 05:00:00", 0],
-                    ["2024-01-13 05:00:00", 0],
-                    ["2024-01-14 05:00:00", 0],
-                    ["2024-01-15 05:00:00", 0],
-                    ["2024-01-16 05:00:00", 0],
-                    ["2024-01-17 05:00:00", 0],
-                    ["2024-01-18 05:00:00", 0],
-                ],
                 intervalType: "DAY",
                 interval: "7d",
             });
@@ -212,10 +168,6 @@ describe("Dashboard route", () => {
             return json({
                 siteId: "@unknown",
                 sites: [],
-                views: [],
-                visits: [],
-                visitors: [],
-                viewsGroupedByInterval: [],
                 intervalType: "day",
             });
         }
@@ -226,6 +178,22 @@ describe("Dashboard route", () => {
                 Component: Dashboard,
                 loader,
                 children: [
+                    {
+                        path: "/resources/timeseries",
+                        loader: () => {
+                            return json({ chartData: [] });
+                        },
+                    },
+                    {
+                        path: "/resources/stats",
+                        loader: () => {
+                            return json({
+                                views: 0,
+                                visits: 0,
+                                visitors: 0,
+                            });
+                        },
+                    },
                     {
                         path: "/resources/paths",
                         loader: () => {
@@ -303,6 +271,22 @@ describe("Dashboard route", () => {
                 Component: Dashboard,
                 loader,
                 children: [
+                    {
+                        path: "/resources/stats",
+                        loader: () => {
+                            return json({
+                                views: 2133,
+                                visits: 80,
+                                visitors: 33,
+                            });
+                        },
+                    },
+                    {
+                        path: "/resources/timeseries",
+                        loader: () => {
+                            return json({});
+                        },
+                    },
                     {
                         path: "/resources/paths",
                         loader: () => {

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -30,6 +30,7 @@ import {
 import { SearchFilters } from "~/lib/types";
 import SearchFilterBadges from "~/components/SearchFilterBadges";
 import { TimeSeriesCard } from "./resources.timeseries";
+import { StatsCard } from "./resources.stats";
 
 export const meta: MetaFunction = () => {
     return [
@@ -87,13 +88,6 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
         `${MAX_RETENTION_DAYS}d`,
     );
 
-    const counts = analyticsEngine.getCounts(
-        actualSiteId,
-        interval,
-        context.cloudflare.cf.timezone as string,
-        filters,
-    );
-
     const intervalType = getIntervalType(interval);
 
     // await all requests to AE then return the results
@@ -105,9 +99,6 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
             sites: (await sitesByHits).map(
                 ([site, _]: [string, number]) => site,
             ),
-            views: (await counts).views,
-            visits: (await counts).visits,
-            visitors: (await counts).visitors,
             intervalType,
             interval,
             filters,
@@ -226,34 +217,12 @@ export default function Dashboard() {
 
             <div className="transition" style={{ opacity: loading ? 0.6 : 1 }}>
                 <div className="w-full mb-4">
-                    <Card>
-                        <div className="p-4 pl-6">
-                            <div className="grid grid-cols-3 gap-10 items-end">
-                                <div>
-                                    <div className="text-md">Views</div>
-                                    <div className="text-4xl">
-                                        {countFormatter.format(data.views)}
-                                    </div>
-                                </div>
-                                <div>
-                                    <div className="text-md sm:text-lg">
-                                        Visits
-                                    </div>
-                                    <div className="text-4xl">
-                                        {countFormatter.format(data.visits)}
-                                    </div>
-                                </div>
-                                <div>
-                                    <div className="text-md sm:text-lg">
-                                        Visitors
-                                    </div>
-                                    <div className="text-4xl">
-                                        {countFormatter.format(data.visitors)}
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </Card>
+                    <StatsCard
+                        siteId={data.siteId}
+                        interval={data.interval}
+                        filters={data.filters}
+                        timezone={userTimezone}
+                    />
                 </div>
                 <div className="w-full mb-4">
                     <TimeSeriesCard

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -306,6 +306,7 @@ export default function Dashboard() {
                         interval={data.interval}
                         filters={data.filters}
                         onFilterChange={handleFilterChange}
+                        timezone={userTimezone}
                     />
 
                     <DeviceCard

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -73,6 +73,8 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
     }
 
     const siteId = url.searchParams.get("site") || "";
+    const actualSiteId = siteId === "@unknown" ? "" : siteId;
+
     const filters = getFiltersFromSearchParams(url.searchParams);
 
     // initiate requests to AE in parallel
@@ -91,7 +93,7 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
     let out;
     try {
         out = {
-            siteId: siteId,
+            siteId: actualSiteId,
             sites: (await sitesByHits).map(
                 ([site, _]: [string, number]) => site,
             ),

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -277,6 +277,7 @@ export default function Dashboard() {
                         siteId={data.siteId}
                         interval={data.interval}
                         filters={data.filters}
+                        timezone={userTimezone}
                     />
                 </div>
                 <div className="grid md:grid-cols-2 gap-4 mb-4">

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -89,7 +89,6 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
     //                will show up in the dropdown.
     const sitesByHits = analyticsEngine.getSitesOrderedByHits(
         `${MAX_RETENTION_DAYS}d`,
-        tz,
     );
 
     const counts = analyticsEngine.getCounts(

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -21,8 +21,6 @@ import { BrowserCard } from "./resources.browser";
 import { CountryCard } from "./resources.country";
 import { DeviceCard } from "./resources.device";
 
-import TimeSeriesChart from "~/components/TimeSeriesChart";
-import dayjs from "dayjs";
 import {
     getDateTimeRange,
     getFiltersFromSearchParams,
@@ -80,8 +78,6 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
 
     const filters = getFiltersFromSearchParams(url.searchParams);
 
-    const tz = context.cloudflare.cf.timezone as string;
-
     // initiate requests to AE in parallel
 
     // sites by hits: This is to populate the "sites" dropdown. We query the full retention
@@ -94,21 +90,11 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
     const counts = analyticsEngine.getCounts(
         actualSiteId,
         interval,
-        tz,
+        context.cloudflare.cf.timezone as string,
         filters,
     );
 
     const intervalType = getIntervalType(interval);
-    const { startDate, endDate } = getDateTimeRange(interval, tz);
-
-    const viewsGroupedByInterval = analyticsEngine.getViewsGroupedByInterval(
-        actualSiteId,
-        intervalType,
-        startDate,
-        endDate,
-        tz,
-        filters,
-    );
 
     // await all requests to AE then return the results
 
@@ -122,10 +108,8 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
             views: (await counts).views,
             visits: (await counts).visits,
             visitors: (await counts).visitors,
-            viewsGroupedByInterval: await viewsGroupedByInterval,
             intervalType,
             interval,
-            tz,
             filters,
         };
     } catch (err) {
@@ -285,12 +269,14 @@ export default function Dashboard() {
                         interval={data.interval}
                         filters={data.filters}
                         onFilterChange={handleFilterChange}
+                        timezone={userTimezone}
                     />
                     <ReferrerCard
                         siteId={data.siteId}
                         interval={data.interval}
                         filters={data.filters}
                         onFilterChange={handleFilterChange}
+                        timezone={userTimezone}
                     />
                 </div>
                 <div className="grid md:grid-cols-3 gap-4 mb-4">
@@ -299,6 +285,7 @@ export default function Dashboard() {
                         interval={data.interval}
                         filters={data.filters}
                         onFilterChange={handleFilterChange}
+                        timezone={userTimezone}
                     />
 
                     <CountryCard
@@ -314,6 +301,7 @@ export default function Dashboard() {
                         interval={data.interval}
                         filters={data.filters}
                         onFilterChange={handleFilterChange}
+                        timezone={userTimezone}
                     />
                 </div>
             </div>

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -1,4 +1,3 @@
-import { Card, CardContent } from "~/components/ui/card";
 import {
     Select,
     SelectContent,
@@ -22,7 +21,6 @@ import { CountryCard } from "./resources.country";
 import { DeviceCard } from "./resources.device";
 
 import {
-    getDateTimeRange,
     getFiltersFromSearchParams,
     getIntervalType,
     getUserTimezone,
@@ -75,8 +73,6 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
     }
 
     const siteId = url.searchParams.get("site") || "";
-    const actualSiteId = siteId == "@unknown" ? "" : siteId;
-
     const filters = getFiltersFromSearchParams(url.searchParams);
 
     // initiate requests to AE in parallel
@@ -135,8 +131,6 @@ export default function Dashboard() {
             return prev;
         });
     }
-
-    const countFormatter = Intl.NumberFormat("en", { notation: "compact" });
 
     const handleFilterChange = (filters: SearchFilters) => {
         setSearchParams((prev) => {

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -162,14 +162,6 @@ export default function Dashboard() {
         });
     }
 
-    const chartData: { date: string; views: number }[] = [];
-    data.viewsGroupedByInterval.forEach((row) => {
-        chartData.push({
-            date: row[0],
-            views: row[1],
-        });
-    });
-
     const countFormatter = Intl.NumberFormat("en", { notation: "compact" });
 
     const handleFilterChange = (filters: SearchFilters) => {

--- a/app/routes/resources.browser.tsx
+++ b/app/routes/resources.browser.tsx
@@ -3,11 +3,7 @@ import { useFetcher } from "@remix-run/react";
 import type { LoaderFunctionArgs } from "@remix-run/cloudflare";
 import { json } from "@remix-run/cloudflare";
 
-import {
-    getFiltersFromSearchParams,
-    paramsFromUrl,
-    getUserTimezone,
-} from "~/lib/utils";
+import { getFiltersFromSearchParams, paramsFromUrl } from "~/lib/utils";
 import PaginatedTableCard from "~/components/PaginatedTableCard";
 import { SearchFilters } from "~/lib/types";
 
@@ -15,10 +11,9 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     const { analyticsEngine } = context;
 
     const { interval, site, page = 1 } = paramsFromUrl(request.url);
-    const tz = context.cloudflare.cf.timezone as string;
-
     const url = new URL(request.url);
-    const filters = getFiltersFromSearchParams(new URL(url).searchParams);
+    const tz = url.searchParams.get("timezone") || "UTC";
+    const filters = getFiltersFromSearchParams(url.searchParams);
 
     return json({
         countsByProperty: await analyticsEngine.getCountByBrowser(
@@ -37,14 +32,14 @@ export const BrowserCard = ({
     interval,
     filters,
     onFilterChange,
+    timezone,
 }: {
     siteId: string;
     interval: string;
     filters: SearchFilters;
     onFilterChange: (filters: SearchFilters) => void;
+    timezone: string;
 }) => {
-    const userTimezone = getUserTimezone();
-
     return (
         <PaginatedTableCard
             siteId={siteId}
@@ -56,7 +51,7 @@ export const BrowserCard = ({
             onClick={(browserName) =>
                 onFilterChange({ ...filters, browserName })
             }
-            timezone={userTimezone}
+            timezone={timezone}
         />
     );
 };

--- a/app/routes/resources.browser.tsx
+++ b/app/routes/resources.browser.tsx
@@ -3,7 +3,11 @@ import { useFetcher } from "@remix-run/react";
 import type { LoaderFunctionArgs } from "@remix-run/cloudflare";
 import { json } from "@remix-run/cloudflare";
 
-import { getFiltersFromSearchParams, paramsFromUrl } from "~/lib/utils";
+import {
+    getFiltersFromSearchParams,
+    paramsFromUrl,
+    getUserTimezone,
+} from "~/lib/utils";
 import PaginatedTableCard from "~/components/PaginatedTableCard";
 import { SearchFilters } from "~/lib/types";
 
@@ -39,6 +43,8 @@ export const BrowserCard = ({
     filters: SearchFilters;
     onFilterChange: (filters: SearchFilters) => void;
 }) => {
+    const userTimezone = getUserTimezone();
+
     return (
         <PaginatedTableCard
             siteId={siteId}
@@ -50,6 +56,7 @@ export const BrowserCard = ({
             onClick={(browserName) =>
                 onFilterChange({ ...filters, browserName })
             }
+            timezone={userTimezone}
         />
     );
 };

--- a/app/routes/resources.country.tsx
+++ b/app/routes/resources.country.tsx
@@ -48,14 +48,12 @@ export const CountryCard = ({
     onFilterChange: (filters: SearchFilters) => void;
     timezone: string;
 }) => {
-    const dataFetcher = useFetcher<typeof loader>();
-
     return (
         <PaginatedTableCard
             siteId={siteId}
             interval={interval}
             columnHeaders={["Country", "Visitors"]}
-            dataFetcher={dataFetcher}
+            dataFetcher={useFetcher<typeof loader>()}
             loaderUrl="/resources/country"
             filters={filters}
             onClick={(country) => onFilterChange({ ...filters, country })}

--- a/app/routes/resources.country.tsx
+++ b/app/routes/resources.country.tsx
@@ -1,41 +1,18 @@
 import { useFetcher } from "@remix-run/react";
-
 import type { LoaderFunctionArgs } from "@remix-run/cloudflare";
 import { json } from "@remix-run/cloudflare";
-
 import { getFiltersFromSearchParams, paramsFromUrl } from "~/lib/utils";
 import PaginatedTableCard from "~/components/PaginatedTableCard";
 import { SearchFilters } from "~/lib/types";
 
-function convertCountryCodesToNames(
-    countByCountry: [string, number][],
-): [[string, string], number][] {
-    const regionNames = new Intl.DisplayNames(["en"], { type: "region" });
-    return countByCountry.map((countByBrowserRow) => {
-        let countryName;
-        try {
-            // throws an exception if country code isn't valid
-            //   use try/catch to be defensive and not explode if an invalid
-            //   country code gets insrted into Analytics Engine
-            countryName = regionNames.of(countByBrowserRow[0])!; // "United States"
-        } catch (err) {
-            countryName = "(unknown)";
-        }
-        const count = countByBrowserRow[1];
-        return [[countByBrowserRow[0], countryName], count];
-    });
-}
-
 export async function loader({ context, request }: LoaderFunctionArgs) {
     const { analyticsEngine } = context;
-
     const { interval, site, page = 1 } = paramsFromUrl(request.url);
-    const tz = context.cloudflare.cf.timezone as string;
-
     const url = new URL(request.url);
-    const filters = getFiltersFromSearchParams(new URL(url).searchParams);
+    const tz = url.searchParams.get("timezone") || "UTC";
+    const filters = getFiltersFromSearchParams(url.searchParams);
 
-    const countByCountry = await analyticsEngine.getCountByCountry(
+    const countsByCountry = await analyticsEngine.getCountByCountry(
         site,
         interval,
         tz,
@@ -46,11 +23,14 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     // normalize country codes to country names
     // NOTE: this must be done ONLY on server otherwise hydration mismatches
     //       can occur because Intl.DisplayNames produces different results
-    //       in different browsers (see )
-    const normalizedCountByCountry = convertCountryCodesToNames(countByCountry);
+    //       in different browsers (see https://github.com/benvinegar/counterscale/issues/72)
+    const countsByProperty = countsByCountry.map(([code, count]) => [
+        convertCountryCodesToNames(code),
+        count,
+    ]);
 
     return json({
-        countsByProperty: normalizedCountByCountry,
+        countsByProperty,
         page: Number(page),
     });
 }
@@ -60,21 +40,42 @@ export const CountryCard = ({
     interval,
     filters,
     onFilterChange,
+    timezone,
 }: {
     siteId: string;
     interval: string;
     filters: SearchFilters;
     onFilterChange: (filters: SearchFilters) => void;
+    timezone: string;
 }) => {
+    const dataFetcher = useFetcher<typeof loader>();
+
     return (
         <PaginatedTableCard
             siteId={siteId}
             interval={interval}
             columnHeaders={["Country", "Visitors"]}
-            dataFetcher={useFetcher<typeof loader>()}
+            dataFetcher={dataFetcher}
             loaderUrl="/resources/country"
             filters={filters}
             onClick={(country) => onFilterChange({ ...filters, country })}
+            timezone={timezone}
         />
     );
 };
+
+// Helper function to convert country codes to names
+function convertCountryCodesToNames(countryCode: string): string {
+    try {
+        return (
+            new Intl.DisplayNames(["en"], { type: "region" }).of(
+                countryCode.toUpperCase(),
+            ) || countryCode
+        );
+    } catch (e) {
+        // throws an exception if country code isn't valid
+        //   use try/catch to be defensive and not explode if an invalid
+        //   country code gets insrted into Analytics Engine
+        return "(unknown)";
+    }
+}

--- a/app/routes/resources.device.tsx
+++ b/app/routes/resources.device.tsx
@@ -11,10 +11,10 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     const { analyticsEngine } = context;
 
     const { interval, site, page = 1 } = paramsFromUrl(request.url);
-    const tz = context.cloudflare.cf.timezone as string;
 
     const url = new URL(request.url);
-    const filters = getFiltersFromSearchParams(new URL(url).searchParams);
+    const tz = url.searchParams.get("timezone") || "UTC";
+    const filters = getFiltersFromSearchParams(url.searchParams);
 
     return json({
         countsByProperty: await analyticsEngine.getCountByDevice(
@@ -33,11 +33,13 @@ export const DeviceCard = ({
     interval,
     filters,
     onFilterChange,
+    timezone,
 }: {
     siteId: string;
     interval: string;
     filters: SearchFilters;
     onFilterChange: (filters: SearchFilters) => void;
+    timezone: string;
 }) => {
     return (
         <PaginatedTableCard
@@ -50,6 +52,7 @@ export const DeviceCard = ({
             onClick={(deviceModel) =>
                 onFilterChange({ ...filters, deviceModel })
             }
+            timezone={timezone}
         />
     );
 };

--- a/app/routes/resources.paths.tsx
+++ b/app/routes/resources.paths.tsx
@@ -14,10 +14,10 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     const { analyticsEngine } = context;
 
     const { interval, site, page = 1 } = paramsFromUrl(request.url);
-    const tz = context.cloudflare.cf.timezone as string;
 
     const url = new URL(request.url);
-    const filters = getFiltersFromSearchParams(new URL(url).searchParams);
+    const tz = url.searchParams.get("timezone") || "UTC";
+    const filters = getFiltersFromSearchParams(url.searchParams);
 
     return json({
         countsByProperty: await analyticsEngine.getCountByPath(

--- a/app/routes/resources.paths.tsx
+++ b/app/routes/resources.paths.tsx
@@ -36,11 +36,13 @@ export const PathsCard = ({
     interval,
     filters,
     onFilterChange,
+    timezone,
 }: {
     siteId: string;
     interval: string;
     filters: SearchFilters;
     onFilterChange: (filters: SearchFilters) => void;
+    timezone: string;
 }) => {
     return (
         <PaginatedTableCard
@@ -51,6 +53,7 @@ export const PathsCard = ({
             filters={filters}
             loaderUrl="/resources/paths"
             onClick={(path) => onFilterChange({ ...filters, path })}
+            timezone={timezone}
         />
     );
 };

--- a/app/routes/resources.referrer.tsx
+++ b/app/routes/resources.referrer.tsx
@@ -12,10 +12,10 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     const { analyticsEngine } = context;
 
     const { interval, site, page = 1 } = paramsFromUrl(request.url);
-    const tz = context.cloudflare.cf.timezone as string;
 
     const url = new URL(request.url);
-    const filters = getFiltersFromSearchParams(new URL(url).searchParams);
+    const tz = url.searchParams.get("timezone") || "UTC";
+    const filters = getFiltersFromSearchParams(url.searchParams);
 
     return json({
         countsByProperty: await analyticsEngine.getCountByReferrer(
@@ -34,11 +34,13 @@ export const ReferrerCard = ({
     interval,
     filters,
     onFilterChange,
+    timezone,
 }: {
     siteId: string;
     interval: string;
     filters: SearchFilters;
     onFilterChange: (filters: SearchFilters) => void;
+    timezone: string;
 }) => {
     return (
         <PaginatedTableCard
@@ -49,6 +51,7 @@ export const ReferrerCard = ({
             loaderUrl="/resources/referrer"
             filters={filters}
             onClick={(referrer) => onFilterChange({ ...filters, referrer })}
+            timezone={timezone}
         />
     );
 };

--- a/app/routes/resources.stats.tsx
+++ b/app/routes/resources.stats.tsx
@@ -1,0 +1,89 @@
+import type { LoaderFunctionArgs } from "@remix-run/cloudflare";
+import { json } from "@remix-run/cloudflare";
+import { getFiltersFromSearchParams, paramsFromUrl } from "~/lib/utils";
+import { useEffect } from "react";
+import { useFetcher } from "@remix-run/react";
+import { Card } from "~/components/ui/card";
+import { SearchFilters } from "~/lib/types";
+
+export async function loader({ context, request }: LoaderFunctionArgs) {
+    const { analyticsEngine } = context;
+    const { interval, site } = paramsFromUrl(request.url);
+    const url = new URL(request.url);
+    const tz = url.searchParams.get("timezone") || "UTC";
+    const filters = getFiltersFromSearchParams(url.searchParams);
+
+    const counts = await analyticsEngine.getCounts(site, interval, tz, filters);
+
+    return json({
+        views: counts.views,
+        visits: counts.visits,
+        visitors: counts.visitors,
+    });
+}
+
+export const StatsCard = ({
+    siteId,
+    interval,
+    filters,
+    timezone,
+}: {
+    siteId: string;
+    interval: string;
+    filters: SearchFilters;
+    timezone: string;
+}) => {
+    const dataFetcher = useFetcher<typeof loader>();
+    const { views, visits, visitors } = dataFetcher.data || {};
+    const countFormatter = Intl.NumberFormat("en", { notation: "compact" });
+
+    const loadData = () => {
+        const filterString = filters
+            ? Object.entries(filters)
+                  .map(([key, value]) => `&${key}=${value}`)
+                  .join("")
+            : "";
+
+        const url = `/resources/stats?site=${siteId}&interval=${interval}&timezone=${timezone}${filterString}`;
+        dataFetcher.load(url);
+    };
+
+    useEffect(() => {
+        if (dataFetcher.state === "idle") {
+            loadData();
+        }
+    }, []);
+
+    useEffect(() => {
+        if (dataFetcher.state === "idle") {
+            loadData();
+        }
+    }, [siteId, interval, filters]);
+
+    return (
+        <Card>
+            <div className="p-4 pl-6">
+                <div className="grid grid-cols-3 gap-10 items-end">
+                    <div>
+                        <div className="text-md">Views</div>
+                        <div className="text-4xl">
+                            {views ? countFormatter.format(views) : "-"}
+                        </div>
+                    </div>
+                    <div>
+                        <div className="text-md sm:text-lg">Visits</div>
+                        <div className="text-4xl">
+                            {visits ? countFormatter.format(visits) : "-"}
+                        </div>
+                    </div>
+                    <div>
+                        <div className="text-md sm:text-lg">Visitors</div>
+                        <div className="text-4xl">
+                            {visitors ? countFormatter.format(visitors) : "-"}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </Card>
+    );
+};

--- a/app/routes/resources.timeseries.tsx
+++ b/app/routes/resources.timeseries.tsx
@@ -33,8 +33,16 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
             filters,
         );
 
+    const chartData: { date: string; views: number }[] = [];
+    viewsGroupedByInterval.forEach((row) => {
+        chartData.push({
+            date: row[0],
+            views: row[1],
+        });
+    });
+
     return json({
-        chartData: viewsGroupedByInterval,
+        chartData: chartData,
         intervalType: intervalType,
     });
 }

--- a/app/routes/resources.timeseries.tsx
+++ b/app/routes/resources.timeseries.tsx
@@ -60,18 +60,28 @@ export const TimeSeriesCard = ({
     const dataFetcher = useFetcher<typeof loader>();
     const { chartData, intervalType } = dataFetcher.data || {};
 
-    useEffect(() => {
-        if (dataFetcher.state === "idle" && !dataFetcher.data) {
-            const filterString = filters
-                ? Object.entries(filters)
-                      .map(([key, value]) => `&${key}=${value}`)
-                      .join("")
-                : "";
+    const loadData = () => {
+        const filterString = filters
+            ? Object.entries(filters)
+                  .map(([key, value]) => `&${key}=${value}`)
+                  .join("")
+            : "";
 
-            const url = `/resources/timeseries?site=${siteId}&interval=${interval}&timezone=${timezone}${filterString}`;
-            dataFetcher.load(url);
+        const url = `/resources/timeseries?site=${siteId}&interval=${interval}&timezone=${timezone}${filterString}`;
+        dataFetcher.load(url);
+    };
+
+    useEffect(() => {
+        if (dataFetcher.state === "idle") {
+            loadData();
         }
-    }, [siteId, interval, filters, timezone]);
+    }, []);
+
+    useEffect(() => {
+        if (dataFetcher.state === "idle") {
+            loadData();
+        }
+    }, [siteId, interval, filters]);
 
     return (
         <Card>

--- a/app/routes/resources.timeseries.tsx
+++ b/app/routes/resources.timeseries.tsx
@@ -1,0 +1,81 @@
+import type { LoaderFunctionArgs } from "@remix-run/cloudflare";
+import { json } from "@remix-run/cloudflare";
+import {
+    getFiltersFromSearchParams,
+    paramsFromUrl,
+    getIntervalType,
+    getDateTimeRange,
+} from "~/lib/utils";
+import { useEffect } from "react";
+import { useFetcher } from "@remix-run/react";
+import { Card, CardContent } from "~/components/ui/card";
+import TimeSeriesChart from "~/components/TimeSeriesChart";
+import { SearchFilters } from "~/lib/types";
+
+export async function loader({ context, request }: LoaderFunctionArgs) {
+    const { analyticsEngine } = context;
+    const { interval, site } = paramsFromUrl(request.url);
+    const tz = context.cloudflare.cf.timezone as string;
+
+    const url = new URL(request.url);
+    const filters = getFiltersFromSearchParams(url.searchParams);
+
+    const intervalType = getIntervalType(interval);
+    const { startDate, endDate } = getDateTimeRange(interval, tz);
+
+    const viewsGroupedByInterval =
+        await analyticsEngine.getViewsGroupedByInterval(
+            site,
+            intervalType,
+            startDate,
+            endDate,
+            tz,
+            filters,
+        );
+
+    return json({
+        chartData: viewsGroupedByInterval,
+        intervalType: intervalType,
+    });
+}
+
+export const TimeSeriesCard = ({
+    siteId,
+    interval,
+    filters,
+}: {
+    siteId: string;
+    interval: string;
+    filters: SearchFilters;
+}) => {
+    const dataFetcher = useFetcher<typeof loader>();
+    const { chartData, intervalType } = dataFetcher.data || {};
+
+    useEffect(() => {
+        if (dataFetcher.state === "idle" && !dataFetcher.data) {
+            const filterString = filters
+                ? Object.entries(filters)
+                      .map(([key, value]) => `&${key}=${value}`)
+                      .join("")
+                : "";
+
+            const url = `/resources/timeseries?site=${siteId}&interval=${interval}${filterString}`;
+            dataFetcher.load(url);
+        }
+    }, [siteId, interval, filters]);
+
+    return (
+        <Card>
+            <CardContent>
+                <div className="h-72 pt-6 -m-4 -ml-8 sm:m-0">
+                    {chartData && (
+                        <TimeSeriesChart
+                            data={chartData}
+                            intervalType={intervalType}
+                        />
+                    )}
+                </div>
+            </CardContent>
+        </Card>
+    );
+};

--- a/app/routes/resources.timeseries.tsx
+++ b/app/routes/resources.timeseries.tsx
@@ -15,9 +15,8 @@ import { SearchFilters } from "~/lib/types";
 export async function loader({ context, request }: LoaderFunctionArgs) {
     const { analyticsEngine } = context;
     const { interval, site } = paramsFromUrl(request.url);
-    const tz = context.cloudflare.cf.timezone as string;
-
     const url = new URL(request.url);
+    const tz = url.searchParams.get("timezone") || "UTC";
     const filters = getFiltersFromSearchParams(url.searchParams);
 
     const intervalType = getIntervalType(interval);
@@ -51,10 +50,12 @@ export const TimeSeriesCard = ({
     siteId,
     interval,
     filters,
+    timezone,
 }: {
     siteId: string;
     interval: string;
     filters: SearchFilters;
+    timezone: string;
 }) => {
     const dataFetcher = useFetcher<typeof loader>();
     const { chartData, intervalType } = dataFetcher.data || {};
@@ -67,10 +68,10 @@ export const TimeSeriesCard = ({
                       .join("")
                 : "";
 
-            const url = `/resources/timeseries?site=${siteId}&interval=${interval}${filterString}`;
+            const url = `/resources/timeseries?site=${siteId}&interval=${interval}&timezone=${timezone}${filterString}`;
             dataFetcher.load(url);
         }
-    }, [siteId, interval, filters]);
+    }, [siteId, interval, filters, timezone]);
 
     return (
         <Card>
@@ -80,6 +81,7 @@ export const TimeSeriesCard = ({
                         <TimeSeriesChart
                             data={chartData}
                             intervalType={intervalType}
+                            timezone={timezone}
                         />
                     )}
                 </div>


### PR DESCRIPTION
Fixes #109 and #107

This is a major change that removes all server-side rendered React, so that the app can first inspect the user's browser timezone, and pass that along to every component.

By doing so, we avoid having to use Cloudflare Worker's `cf.timezone` property, which can create confusing scenarios (like #107) when the user's internet doesn't route through the timezone they're located in (e.g. when using a VPN or proxy).