### PR TITLE
Reduce card data fetching complexity

### DIFF
--- a/app/components/PaginatedTableCard.tsx
+++ b/app/components/PaginatedTableCard.tsx
@@ -42,7 +42,7 @@ const PaginatedTableCard = ({
             method: "get",
             action: loaderUrl,
         });
-        // NOTE: dataFetcher is intentionally omitted from the useEffectdependency array
+        // NOTE: dataFetcher is intentionally omitted from the useEffect dependency array
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [loaderUrl, siteId, interval, filters, timezone, page]); //
 

--- a/app/components/PaginatedTableCard.tsx
+++ b/app/components/PaginatedTableCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import TableCard from "~/components/TableCard";
 
 import { Card } from "./ui/card";
@@ -27,38 +27,27 @@ const PaginatedTableCard = ({
     timezone,
 }: PaginatedTableCardProps) => {
     const countsByProperty = dataFetcher.data?.countsByProperty || [];
-    const page = dataFetcher.data?.page || 1;
-
-    const loadData = (page: string | undefined = undefined) => {
-        // turn filters into query string
-        const filterString = filters
-            ? Object.entries(filters)
-                  .map(([key, value]) => `&${key}=${value}`)
-                  .join("")
-            : "";
-
-        let url = `${loaderUrl}?site=${siteId}&interval=${interval}&timezone=${timezone}${filterString}`;
-        if (page) {
-            url += `&page=${page}`;
-        }
-
-        dataFetcher.load(url);
-    };
+    const [page, setPage] = useState(1);
 
     useEffect(() => {
-        if (dataFetcher.state === "idle") {
-            loadData();
-        }
-    }, []);
+        const params = {
+            site: siteId,
+            interval,
+            timezone,
+            ...filters,
+            page,
+        };
 
-    useEffect(() => {
-        if (dataFetcher.state === "idle") {
-            loadData();
-        }
-    }, [siteId, interval, filters]);
+        dataFetcher.submit(params, {
+            method: "get",
+            action: loaderUrl,
+        });
+        // NOTE: dataFetcher is intentionally omitted from the useEffectdependency array
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [loaderUrl, siteId, interval, filters, timezone, page]); //
 
     function handlePagination(page: number) {
-        loadData(page.toString());
+        setPage(page);
     }
 
     const hasMore = countsByProperty.length === 10;

--- a/app/routes/resources.stats.tsx
+++ b/app/routes/resources.stats.tsx
@@ -34,31 +34,25 @@ export const StatsCard = ({
     timezone: string;
 }) => {
     const dataFetcher = useFetcher<typeof loader>();
+
     const { views, visits, visitors } = dataFetcher.data || {};
     const countFormatter = Intl.NumberFormat("en", { notation: "compact" });
 
-    const loadData = () => {
-        const filterString = filters
-            ? Object.entries(filters)
-                  .map(([key, value]) => `&${key}=${value}`)
-                  .join("")
-            : "";
-
-        const url = `/resources/stats?site=${siteId}&interval=${interval}&timezone=${timezone}${filterString}`;
-        dataFetcher.load(url);
-    };
-
     useEffect(() => {
-        if (dataFetcher.state === "idle") {
-            loadData();
-        }
-    }, []);
+        if (dataFetcher.state !== "idle") return;
 
-    useEffect(() => {
-        if (dataFetcher.state === "idle") {
-            loadData();
-        }
-    }, [siteId, interval, filters]);
+        const params = {
+            site: siteId,
+            interval,
+            timezone,
+            ...filters,
+        };
+
+        dataFetcher.submit(params, {
+            method: "get",
+            action: `/resources/stats`,
+        });
+    }, [dataFetcher, siteId, interval, filters, timezone]);
 
     return (
         <Card>

--- a/app/routes/resources.stats.tsx
+++ b/app/routes/resources.stats.tsx
@@ -39,8 +39,6 @@ export const StatsCard = ({
     const countFormatter = Intl.NumberFormat("en", { notation: "compact" });
 
     useEffect(() => {
-        if (dataFetcher.state !== "idle") return;
-
         const params = {
             site: siteId,
             interval,
@@ -52,7 +50,9 @@ export const StatsCard = ({
             method: "get",
             action: `/resources/stats`,
         });
-    }, [dataFetcher, siteId, interval, filters, timezone]);
+        // NOTE: dataFetcher is intentionally omitted from the useEffectdependency array
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [siteId, interval, filters, timezone]);
 
     return (
         <Card>

--- a/app/routes/resources.stats.tsx
+++ b/app/routes/resources.stats.tsx
@@ -50,7 +50,7 @@ export const StatsCard = ({
             method: "get",
             action: `/resources/stats`,
         });
-        // NOTE: dataFetcher is intentionally omitted from the useEffectdependency array
+        // NOTE: dataFetcher is intentionally omitted from the useEffect dependency array
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [siteId, interval, filters, timezone]);
 

--- a/app/routes/resources.timeseries.tsx
+++ b/app/routes/resources.timeseries.tsx
@@ -60,28 +60,21 @@ export const TimeSeriesCard = ({
     const dataFetcher = useFetcher<typeof loader>();
     const { chartData, intervalType } = dataFetcher.data || {};
 
-    const loadData = () => {
-        const filterString = filters
-            ? Object.entries(filters)
-                  .map(([key, value]) => `&${key}=${value}`)
-                  .join("")
-            : "";
-
-        const url = `/resources/timeseries?site=${siteId}&interval=${interval}&timezone=${timezone}${filterString}`;
-        dataFetcher.load(url);
-    };
-
     useEffect(() => {
-        if (dataFetcher.state === "idle") {
-            loadData();
-        }
-    }, []);
+        const params = {
+            site: siteId,
+            interval,
+            timezone,
+            ...filters,
+        };
 
-    useEffect(() => {
-        if (dataFetcher.state === "idle") {
-            loadData();
-        }
-    }, [siteId, interval, filters]);
+        dataFetcher.submit(params, {
+            method: "get",
+            action: `/resources/timeseries`,
+        });
+        // NOTE: dataFetcher is intentionally omitted from the useEffectdependency array
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [siteId, interval, filters, timezone]);
 
     return (
         <Card>

--- a/app/routes/resources.timeseries.tsx
+++ b/app/routes/resources.timeseries.tsx
@@ -72,7 +72,7 @@ export const TimeSeriesCard = ({
             method: "get",
             action: `/resources/timeseries`,
         });
-        // NOTE: dataFetcher is intentionally omitted from the useEffectdependency array
+        // NOTE: dataFetcher is intentionally omitted from the useEffect dependency array
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [siteId, interval, filters, timezone]);
 


### PR DESCRIPTION
This does a few things:

- In `PaginatedTableCard`, refactors `page` to be a state variable (using `useState`), with corresponding data fetches occurring automatically via `useEffect`
- Instead of manually assembling query strings when calling `dataFetcher.load`, instead passes a dictionary of params to `dataFetcher.submit`
- Removes redundant `useEffect` calls with no dependencies (these didn't do anything)
- Removes some eslint warnings