### PR TITLE
Adding Bounce Tracking

### DIFF
--- a/app/analytics/__tests__/collect.test.ts
+++ b/app/analytics/__tests__/collect.test.ts
@@ -230,17 +230,20 @@ describe("collectRequestHandler", () => {
             } as AnalyticsEngineDataset,
         } as Env;
 
-        // midnight
-        const midnight = new Date(Math.floor(Date.now() / 8.64e7) * 8.64e7);
-        // set system time to midnight to see how the bounce works at the margin
+        const midnight = new Date();
+        midnight.setHours(0, 0, 0, 0);
+
         vi.setSystemTime(midnight.getTime());
-        // increment to one second after midnight
-        midnight.setSeconds(midnight.getSeconds() + 1);
+
+        const midnightPlusOneSecond = new Date(midnight.getTime());
+        midnightPlusOneSecond.setSeconds(
+            midnightPlusOneSecond.getSeconds() + 1,
+        );
 
         const request = httpMocks.createRequest(
             // @ts-expect-error - we're mocking the request object
             generateRequestParams({
-                "if-modified-since": midnight.toUTCString(),
+                "if-modified-since": midnightPlusOneSecond.toUTCString(),
             }),
         );
 
@@ -264,18 +267,22 @@ describe("collectRequestHandler", () => {
             } as AnalyticsEngineDataset,
         } as Env;
 
-        // midnight
-        const midnight = new Date(Math.floor(Date.now() / 8.64e7) * 8.64e7);
-        // set system to one second after midnight
-        midnight.setSeconds(midnight.getSeconds() + 1);
-        vi.setSystemTime(midnight.getTime());
-        // increment to two seconds after midnight
-        midnight.setSeconds(midnight.getSeconds() + 1);
+        const midnightPlusOneSecond = new Date();
+        midnightPlusOneSecond.setHours(0, 0, 1, 0);
+
+        vi.setSystemTime(midnightPlusOneSecond.getTime());
+
+        const midnightPlusTwoSeconds = new Date(
+            midnightPlusOneSecond.getTime(),
+        );
+        midnightPlusTwoSeconds.setSeconds(
+            midnightPlusTwoSeconds.getSeconds() + 1,
+        );
 
         const request = httpMocks.createRequest(
             // @ts-expect-error - we're mocking the request object
             generateRequestParams({
-                "if-modified-since": midnight.toUTCString(),
+                "if-modified-since": midnightPlusTwoSeconds.toUTCString(),
             }),
         );
 

--- a/app/analytics/__tests__/collect.test.ts
+++ b/app/analytics/__tests__/collect.test.ts
@@ -250,9 +250,9 @@ describe("collectRequestHandler", () => {
         expect((writeDataPoint as Mock).mock.calls[0][0]).toHaveProperty(
             "doubles",
             [
-                0, // new visitor because > 24 hours passed
-                0, // new session because > 30 minutes passed
-                -1, // new visitor so bounce
+                0, // NOT a new visitor
+                0, // NOT a new session
+                -1, // First visit after the initial visit so decrement bounce
             ],
         );
     });
@@ -285,9 +285,9 @@ describe("collectRequestHandler", () => {
         expect((writeDataPoint as Mock).mock.calls[0][0]).toHaveProperty(
             "doubles",
             [
-                0, // new visitor because > 24 hours passed
-                0, // new session because > 30 minutes passed
-                0, // new visitor so bounce
+                0, // NOT a new visitor
+                0, // NOT a new session
+                0, // After the second visit so no bounce
             ],
         );
     });

--- a/app/analytics/__tests__/collect.test.ts
+++ b/app/analytics/__tests__/collect.test.ts
@@ -69,7 +69,7 @@ describe("collectRequestHandler", () => {
             ],
             doubles: [
                 1, // new visitor
-                1, // new session
+                0, // DEAD COLUMN (was session)
                 1, // new visit, so bounce
             ],
             indexes: [
@@ -95,7 +95,7 @@ describe("collectRequestHandler", () => {
             "doubles",
             [
                 1, // new visitor
-                1, // new session
+                0, // DEAD COLUMN (was session)
                 1, // new visit, so bounce
             ],
         );
@@ -124,7 +124,7 @@ describe("collectRequestHandler", () => {
             "doubles",
             [
                 0, // NOT a new visitor
-                0, // NOT a new session
+                0, // DEAD COLUMN (was session)
                 0, // NOT first or second visit
             ],
         );
@@ -158,8 +158,7 @@ describe("collectRequestHandler", () => {
             "doubles",
             [
                 1, // new visitor because a new day began
-                0, // NOT a new session because continuation of earlier session (< 30 mins)
-                // (session logic doesn't care if a new day began or not)
+                0, // DEAD COLUMN (was session)
                 1, // new visitor so bounce counted
             ],
         );
@@ -188,7 +187,7 @@ describe("collectRequestHandler", () => {
             "doubles",
             [
                 1, // new visitor because > 30 days passed
-                1, // new session because > 30 minutes passed
+                0, // DEAD COLUMN (was session)
                 1, // new visitor so bounce
             ],
         );
@@ -217,7 +216,7 @@ describe("collectRequestHandler", () => {
             "doubles",
             [
                 1, // new visitor because > 24 hours passed
-                1, // new session because > 30 minutes passed
+                0, // DEAD COLUMN (was session)
                 1, // new visitor so bounce
             ],
         );
@@ -254,7 +253,7 @@ describe("collectRequestHandler", () => {
             "doubles",
             [
                 0, // NOT a new visitor
-                0, // NOT a new session
+                0, // DEAD COLUMN (was session)
                 -1, // First visit after the initial visit so decrement bounce
             ],
         );
@@ -293,7 +292,7 @@ describe("collectRequestHandler", () => {
             "doubles",
             [
                 0, // NOT a new visitor
-                0, // NOT a new session
+                0, // DEAD COLUMN (was session)
                 0, // After the second visit so no bounce
             ],
         );

--- a/app/analytics/__tests__/collect.test.ts
+++ b/app/analytics/__tests__/collect.test.ts
@@ -108,15 +108,12 @@ describe("collectRequestHandler", () => {
             } as AnalyticsEngineDataset,
         } as Env;
 
-        const fiveMinutes = new Date(
-            Date.now() - 5 * 60 * 1000, // 5 mins ago
-        );
-        fiveMinutes.setMilliseconds(1);
-
         const request = httpMocks.createRequest(
             // @ts-expect-error - we're mocking the request object
             generateRequestParams({
-                "if-modified-since": fiveMinutes.toISOString(),
+                "if-modified-since": new Date(
+                    Date.now() - 5 * 60 * 1000, // 5 mins ago
+                ).toUTCString(),
             }),
         );
 
@@ -150,7 +147,7 @@ describe("collectRequestHandler", () => {
             generateRequestParams({
                 "if-modified-since": new Date(
                     Date.now() - 25 * 60 * 1000, // 25 minutes ago
-                ).toISOString(),
+                ).toUTCString(),
             }),
         );
 
@@ -180,7 +177,7 @@ describe("collectRequestHandler", () => {
             generateRequestParams({
                 "if-modified-since": new Date(
                     Date.now() - 31 * 24 * 60 * 60 * 1000, // 31 days ago
-                ).toISOString(),
+                ).toUTCString(),
             }),
         );
 
@@ -209,7 +206,7 @@ describe("collectRequestHandler", () => {
             generateRequestParams({
                 "if-modified-since": new Date(
                     Date.now() - 24 * 60 * 60 * 1000, // 24 hours ago
-                ).toISOString(),
+                ).toUTCString(),
             }),
         );
 
@@ -226,20 +223,27 @@ describe("collectRequestHandler", () => {
         );
     });
 
-    test("if-modified-since has zero milliseconds", () => {
+    test("if-modified-since is one second after midnight", () => {
         const env = {
             WEB_COUNTER_AE: {
                 writeDataPoint: vi.fn(),
             } as AnalyticsEngineDataset,
         } as Env;
 
-        const now = new Date();
-        now.setMilliseconds(0);
+        const midnight = new Date();
+        midnight.setHours(0, 0, 0, 0);
+
+        vi.setSystemTime(midnight.getTime());
+
+        const midnightPlusOneSecond = new Date(midnight.getTime());
+        midnightPlusOneSecond.setSeconds(
+            midnightPlusOneSecond.getSeconds() + 1,
+        );
 
         const request = httpMocks.createRequest(
             // @ts-expect-error - we're mocking the request object
             generateRequestParams({
-                "if-modified-since": now.toISOString(),
+                "if-modified-since": midnightPlusOneSecond.toUTCString(),
             }),
         );
 
@@ -256,20 +260,29 @@ describe("collectRequestHandler", () => {
         );
     });
 
-    test("if-modified-since has one millisecond", () => {
+    test("if-modified-since is two seconds after midnight", () => {
         const env = {
             WEB_COUNTER_AE: {
                 writeDataPoint: vi.fn(),
             } as AnalyticsEngineDataset,
         } as Env;
 
-        const now = new Date();
-        now.setMilliseconds(1);
+        const midnightPlusOneSecond = new Date();
+        midnightPlusOneSecond.setHours(0, 0, 1, 0);
+
+        vi.setSystemTime(midnightPlusOneSecond.getTime());
+
+        const midnightPlusTwoSeconds = new Date(
+            midnightPlusOneSecond.getTime(),
+        );
+        midnightPlusTwoSeconds.setSeconds(
+            midnightPlusTwoSeconds.getSeconds() + 1,
+        );
 
         const request = httpMocks.createRequest(
             // @ts-expect-error - we're mocking the request object
             generateRequestParams({
-                "if-modified-since": now.toISOString(),
+                "if-modified-since": midnightPlusTwoSeconds.toUTCString(),
             }),
         );
 

--- a/app/analytics/__tests__/collect.test.ts
+++ b/app/analytics/__tests__/collect.test.ts
@@ -108,12 +108,15 @@ describe("collectRequestHandler", () => {
             } as AnalyticsEngineDataset,
         } as Env;
 
+        const fiveMinutes = new Date(
+            Date.now() - 5 * 60 * 1000, // 5 mins ago
+        );
+        fiveMinutes.setMilliseconds(1);
+
         const request = httpMocks.createRequest(
             // @ts-expect-error - we're mocking the request object
             generateRequestParams({
-                "if-modified-since": new Date(
-                    Date.now() - 5 * 60 * 1000, // 5 mins ago
-                ).toUTCString(),
+                "if-modified-since": fiveMinutes.toISOString(),
             }),
         );
 
@@ -147,7 +150,7 @@ describe("collectRequestHandler", () => {
             generateRequestParams({
                 "if-modified-since": new Date(
                     Date.now() - 25 * 60 * 1000, // 25 minutes ago
-                ).toUTCString(),
+                ).toISOString(),
             }),
         );
 
@@ -177,7 +180,7 @@ describe("collectRequestHandler", () => {
             generateRequestParams({
                 "if-modified-since": new Date(
                     Date.now() - 31 * 24 * 60 * 60 * 1000, // 31 days ago
-                ).toUTCString(),
+                ).toISOString(),
             }),
         );
 
@@ -206,7 +209,7 @@ describe("collectRequestHandler", () => {
             generateRequestParams({
                 "if-modified-since": new Date(
                     Date.now() - 24 * 60 * 60 * 1000, // 24 hours ago
-                ).toUTCString(),
+                ).toISOString(),
             }),
         );
 
@@ -223,27 +226,20 @@ describe("collectRequestHandler", () => {
         );
     });
 
-    test("if-modified-since is one second after midnight", () => {
+    test("if-modified-since has zero milliseconds", () => {
         const env = {
             WEB_COUNTER_AE: {
                 writeDataPoint: vi.fn(),
             } as AnalyticsEngineDataset,
         } as Env;
 
-        const midnight = new Date();
-        midnight.setHours(0, 0, 0, 0);
-
-        vi.setSystemTime(midnight.getTime());
-
-        const midnightPlusOneSecond = new Date(midnight.getTime());
-        midnightPlusOneSecond.setSeconds(
-            midnightPlusOneSecond.getSeconds() + 1,
-        );
+        const now = new Date();
+        now.setMilliseconds(0);
 
         const request = httpMocks.createRequest(
             // @ts-expect-error - we're mocking the request object
             generateRequestParams({
-                "if-modified-since": midnightPlusOneSecond.toUTCString(),
+                "if-modified-since": now.toISOString(),
             }),
         );
 
@@ -260,29 +256,20 @@ describe("collectRequestHandler", () => {
         );
     });
 
-    test("if-modified-since is two seconds after midnight", () => {
+    test("if-modified-since has one millisecond", () => {
         const env = {
             WEB_COUNTER_AE: {
                 writeDataPoint: vi.fn(),
             } as AnalyticsEngineDataset,
         } as Env;
 
-        const midnightPlusOneSecond = new Date();
-        midnightPlusOneSecond.setHours(0, 0, 1, 0);
-
-        vi.setSystemTime(midnightPlusOneSecond.getTime());
-
-        const midnightPlusTwoSeconds = new Date(
-            midnightPlusOneSecond.getTime(),
-        );
-        midnightPlusTwoSeconds.setSeconds(
-            midnightPlusTwoSeconds.getSeconds() + 1,
-        );
+        const now = new Date();
+        now.setMilliseconds(1);
 
         const request = httpMocks.createRequest(
             // @ts-expect-error - we're mocking the request object
             generateRequestParams({
-                "if-modified-since": midnightPlusTwoSeconds.toUTCString(),
+                "if-modified-since": now.toISOString(),
             }),
         );
 

--- a/app/analytics/__tests__/query.test.ts
+++ b/app/analytics/__tests__/query.test.ts
@@ -195,16 +195,19 @@ describe("AnalyticsEngineAPI", () => {
                             count: 3,
                             isVisit: 1,
                             isVisitor: 0,
+                            bounce: 1,
                         },
                         {
                             count: 2,
                             isVisit: 0,
                             isVisitor: 0,
+                            bounce: 0,
                         },
                         {
                             count: 1,
                             isVisit: 0,
                             isVisitor: 1,
+                            bounce: -1,
                         },
                     ],
                 }),
@@ -218,6 +221,7 @@ describe("AnalyticsEngineAPI", () => {
                 views: 6,
                 visits: 3,
                 visitors: 1,
+                bounces: 2,
             });
         });
     });
@@ -325,9 +329,10 @@ describe("AnalyticsEngineAPI", () => {
                 "SELECT blob4, " +
                     "double1 as isVisitor, " +
                     "double2 as isVisit, " +
+                    "double3 as bounce, " +
                     "SUM(_sample_interval) as count " +
                     "FROM metricsDataset WHERE timestamp >= NOW() - INTERVAL '7' DAY AND timestamp < NOW() AND blob8 = 'example.com' AND blob4 = 'CA' " +
-                    "GROUP BY blob4, double1, double2 " +
+                    "GROUP BY blob4, double1, double2, double3 " +
                     "ORDER BY count DESC LIMIT 10",
             );
             expect(await result).toEqual({
@@ -335,6 +340,7 @@ describe("AnalyticsEngineAPI", () => {
                     views: 3,
                     visitors: 0,
                     visits: 0,
+                    bounces: 0,
                 },
             });
         });

--- a/app/analytics/__tests__/query.test.ts
+++ b/app/analytics/__tests__/query.test.ts
@@ -187,7 +187,7 @@ describe("AnalyticsEngineAPI", () => {
     });
 
     describe("getCounts", () => {
-        test("should return an object with view, visit, visitor, and bounce counts", async () => {
+        test("should return an object with view, visit, and visitor counts", async () => {
             fetch.mockResolvedValue(
                 createFetchResponse({
                     data: [
@@ -195,19 +195,19 @@ describe("AnalyticsEngineAPI", () => {
                             count: 3,
                             isVisit: 1,
                             isVisitor: 0,
-                            isBounce: 1,
+                            bounce: 1,
                         },
                         {
                             count: 2,
                             isVisit: 0,
                             isVisitor: 0,
-                            isBounce: 0,
+                            bounce: 0,
                         },
                         {
                             count: 1,
                             isVisit: 0,
                             isVisitor: 1,
-                            isBounce: -1,
+                            bounce: -1,
                         },
                     ],
                 }),
@@ -329,7 +329,7 @@ describe("AnalyticsEngineAPI", () => {
                 "SELECT blob4, " +
                     "double1 as isVisitor, " +
                     "double2 as isVisit, " +
-                    "double3 as isBounce, " +
+                    "double3 as bounce, " +
                     "SUM(_sample_interval) as count " +
                     "FROM metricsDataset WHERE timestamp >= NOW() - INTERVAL '7' DAY AND timestamp < NOW() AND blob8 = 'example.com' AND blob4 = 'CA' " +
                     "GROUP BY blob4, double1, double2, double3 " +

--- a/app/analytics/__tests__/query.test.ts
+++ b/app/analytics/__tests__/query.test.ts
@@ -362,6 +362,24 @@ describe("AnalyticsEngineAPI", () => {
                 earliestBounce: new Date(mockBounceTimestamp),
             });
         });
+
+        test("returns only earliest event when no bounces found", async () => {
+            const mockEventTimestamp = "2024-01-01T10:00:00Z";
+
+            // Mock responses for both queries
+            fetch.mockResolvedValueOnce(
+                createFetchResponse({
+                    ok: true,
+                    data: [{ earliestEvent: mockEventTimestamp, isBounce: 0 }],
+                }),
+            );
+
+            const result = await api.getEarliestEvents("test-site");
+            expect(result).toEqual({
+                earliestEvent: new Date(mockEventTimestamp),
+                earliestBounce: null,
+            });
+        });
     });
 });
 

--- a/app/analytics/__tests__/query.test.ts
+++ b/app/analytics/__tests__/query.test.ts
@@ -187,25 +187,22 @@ describe("AnalyticsEngineAPI", () => {
     });
 
     describe("getCounts", () => {
-        test("should return an object with view, visit, and visitor counts", async () => {
+        test("should return an object with view, visitor, and bounce counts", async () => {
             fetch.mockResolvedValue(
                 createFetchResponse({
                     data: [
                         {
                             count: 3,
-                            isVisit: 1,
                             isVisitor: 0,
                             isBounce: 1,
                         },
                         {
                             count: 2,
-                            isVisit: 0,
                             isVisitor: 0,
                             isBounce: 0,
                         },
                         {
                             count: 1,
-                            isVisit: 0,
                             isVisitor: 1,
                             isBounce: -1,
                         },
@@ -219,7 +216,6 @@ describe("AnalyticsEngineAPI", () => {
             expect(fetch).toHaveBeenCalled();
             expect(await result).toEqual({
                 views: 6,
-                visits: 3,
                 visitors: 1,
                 bounces: 2,
             });
@@ -328,18 +324,16 @@ describe("AnalyticsEngineAPI", () => {
             ).toEqual(
                 "SELECT blob4, " +
                     "double1 as isVisitor, " +
-                    "double2 as isVisit, " +
                     "double3 as isBounce, " +
                     "SUM(_sample_interval) as count " +
                     "FROM metricsDataset WHERE timestamp >= NOW() - INTERVAL '7' DAY AND timestamp < NOW() AND blob8 = 'example.com' AND blob4 = 'CA' " +
-                    "GROUP BY blob4, double1, double2, double3 " +
+                    "GROUP BY blob4, double1, double3 " +
                     "ORDER BY count DESC LIMIT 10",
             );
             expect(await result).toEqual({
                 CA: {
                     views: 3,
                     visitors: 0,
-                    visits: 0,
                     bounces: 0,
                 },
             });

--- a/app/analytics/__tests__/query.test.ts
+++ b/app/analytics/__tests__/query.test.ts
@@ -339,6 +339,30 @@ describe("AnalyticsEngineAPI", () => {
             });
         });
     });
+
+    describe("getEarliestEvents", () => {
+        test("returns both earliest event and bounce dates when found", async () => {
+            const mockEventTimestamp = "2024-01-01T10:00:00Z";
+            const mockBounceTimestamp = "2024-01-01T12:00:00Z";
+
+            // Mock responses for both queries
+            fetch.mockResolvedValueOnce(
+                createFetchResponse({
+                    ok: true,
+                    data: [
+                        { earliestEvent: mockBounceTimestamp, isBounce: 1 },
+                        { earliestEvent: mockEventTimestamp, isBounce: 0 },
+                    ],
+                }),
+            );
+
+            const result = await api.getEarliestEvents("test-site");
+            expect(result).toEqual({
+                earliestEvent: new Date(mockEventTimestamp),
+                earliestBounce: new Date(mockBounceTimestamp),
+            });
+        });
+    });
 });
 
 describe("intervalToSql", () => {

--- a/app/analytics/__tests__/query.test.ts
+++ b/app/analytics/__tests__/query.test.ts
@@ -187,7 +187,7 @@ describe("AnalyticsEngineAPI", () => {
     });
 
     describe("getCounts", () => {
-        test("should return an object with view, visit, and visitor counts", async () => {
+        test("should return an object with view, visit, visitor, and bounce counts", async () => {
             fetch.mockResolvedValue(
                 createFetchResponse({
                     data: [
@@ -195,19 +195,19 @@ describe("AnalyticsEngineAPI", () => {
                             count: 3,
                             isVisit: 1,
                             isVisitor: 0,
-                            bounce: 1,
+                            isBounce: 1,
                         },
                         {
                             count: 2,
                             isVisit: 0,
                             isVisitor: 0,
-                            bounce: 0,
+                            isBounce: 0,
                         },
                         {
                             count: 1,
                             isVisit: 0,
                             isVisitor: 1,
-                            bounce: -1,
+                            isBounce: -1,
                         },
                     ],
                 }),
@@ -329,7 +329,7 @@ describe("AnalyticsEngineAPI", () => {
                 "SELECT blob4, " +
                     "double1 as isVisitor, " +
                     "double2 as isVisit, " +
-                    "double3 as bounce, " +
+                    "double3 as isBounce, " +
                     "SUM(_sample_interval) as count " +
                     "FROM metricsDataset WHERE timestamp >= NOW() - INTERVAL '7' DAY AND timestamp < NOW() AND blob8 = 'example.com' AND blob4 = 'CA' " +
                     "GROUP BY blob4, double1, double2, double3 " +

--- a/app/analytics/__tests__/query.test.ts
+++ b/app/analytics/__tests__/query.test.ts
@@ -195,19 +195,19 @@ describe("AnalyticsEngineAPI", () => {
                             count: 3,
                             isVisit: 1,
                             isVisitor: 0,
-                            bounce: 1,
+                            isBounce: 1,
                         },
                         {
                             count: 2,
                             isVisit: 0,
                             isVisitor: 0,
-                            bounce: 0,
+                            isBounce: 0,
                         },
                         {
                             count: 1,
                             isVisit: 0,
                             isVisitor: 1,
-                            bounce: -1,
+                            isBounce: -1,
                         },
                     ],
                 }),
@@ -329,7 +329,7 @@ describe("AnalyticsEngineAPI", () => {
                 "SELECT blob4, " +
                     "double1 as isVisitor, " +
                     "double2 as isVisit, " +
-                    "double3 as bounce, " +
+                    "double3 as isBounce, " +
                     "SUM(_sample_interval) as count " +
                     "FROM metricsDataset WHERE timestamp >= NOW() - INTERVAL '7' DAY AND timestamp < NOW() AND blob8 = 'example.com' AND blob4 = 'CA' " +
                     "GROUP BY blob4, double1, double2, double3 " +

--- a/app/analytics/collect.ts
+++ b/app/analytics/collect.ts
@@ -11,30 +11,36 @@ function getNextModifiedDate(current: Date | null, newVisit: boolean): Date {
         current = null;
     }
 
-    const today = new Date();
+    const nextModifiedDate = new Date();
 
     if (!current || newVisit) {
-        today.setMilliseconds(0);
-        return today;
+        nextModifiedDate.setMilliseconds(0);
+        return nextModifiedDate;
     }
 
-    // update bounce
+    // update bounce (tracked in milliseconds)
+    // 3 states of bounce: bounce (0), no bounce (1), done (2)
     switch (current.getMilliseconds()) {
+        // if was bounce move to no bounce
         case 0:
-            today.setMilliseconds(1);
+            nextModifiedDate.setMilliseconds(1);
             break;
+        // if was no bounce move to done
         case 1:
-            today.setMilliseconds(2);
+            nextModifiedDate.setMilliseconds(2);
             break;
+        // set value 3 to indicate done with bounce
         default:
-            today.setMilliseconds(3);
+            nextModifiedDate.setMilliseconds(3);
             break;
     }
 
-    return today;
+    return nextModifiedDate;
 }
 
 function getBounce(current: Date): number {
+    // get bounce value (tracked in milliseconds, see getNextModifiedDate)
+    // bounce (1), no bounce (-1), done (0)
     switch (current.getMilliseconds()) {
         case 0:
             return 1;

--- a/app/analytics/collect.ts
+++ b/app/analytics/collect.ts
@@ -12,6 +12,10 @@ function getMidnightDate(): Date {
 }
 
 function getNextModifiedDate(current: Date | null): Date {
+    if (current && isNaN(current.getTime())) {
+        current = null;
+    }
+
     const midnight = getMidnightDate();
 
     // check if new day, if it is then set to midnight

--- a/app/analytics/collect.ts
+++ b/app/analytics/collect.ts
@@ -12,6 +12,7 @@ function getMidnightDate(): Date {
 }
 
 function getNextModifiedDate(current: Date | null): Date {
+    // in case date is an 'Invalid Date'
     if (current && isNaN(current.getTime())) {
         current = null;
     }

--- a/app/analytics/collect.ts
+++ b/app/analytics/collect.ts
@@ -48,12 +48,9 @@ function getBounce(current: Date | null): number {
 
 function checkVisitorSession(ifModifiedSince: string | null): {
     newVisitor: boolean;
-    newSession: boolean;
 } {
     let newVisitor = true;
-    let newSession = true;
 
-    const minutesUntilSessionResets = 30;
     if (ifModifiedSince) {
         // check today is a new day vs ifModifiedSince
         const today = new Date();
@@ -66,18 +63,9 @@ function checkVisitorSession(ifModifiedSince: string | null): {
             // if ifModifiedSince is today, this is not a new visitor
             newVisitor = false;
         }
-
-        // check ifModifiedSince is less than 30 mins ago
-        if (
-            Date.now() - new Date(ifModifiedSince).getTime() <
-            minutesUntilSessionResets * 60 * 1000
-        ) {
-            // this is a continuation of the same session
-            newSession = false;
-        }
     }
 
-    return { newVisitor, newSession };
+    return { newVisitor };
 }
 
 function extractParamsFromQueryString(requestUrl: string): {
@@ -104,7 +92,7 @@ export function collectRequestHandler(request: Request, env: Env) {
     parsedUserAgent.getBrowser().name;
 
     const ifModifiedSince = request.headers.get("if-modified-since");
-    const { newVisitor, newSession } = checkVisitorSession(ifModifiedSince);
+    const { newVisitor } = checkVisitorSession(ifModifiedSince);
     const modifiedDate = getNextModifiedDate(
         ifModifiedSince ? new Date(ifModifiedSince) : null,
     );
@@ -115,7 +103,7 @@ export function collectRequestHandler(request: Request, env: Env) {
         path: params.p,
         referrer: params.r,
         newVisitor: newVisitor ? 1 : 0,
-        newSession: newSession ? 1 : 0,
+        newSession: 0, // dead column
         bounce: newVisitor ? 1 : getBounce(modifiedDate),
         // user agent stuff
         userAgent: userAgent,

--- a/app/analytics/collect.ts
+++ b/app/analytics/collect.ts
@@ -6,11 +6,9 @@ import type { RequestInit } from "@cloudflare/workers-types";
 // Uses the approach described here: https://notes.normally.com/cookieless-unique-visitor-counts/
 
 function getMidnightDate(): Date {
-    const now = Date.now();
-    // number of milliseconds in a day
-    const day = 8.64e7;
-
-    return new Date(Math.floor(now / day) * day);
+    const midnight = new Date();
+    midnight.setHours(0, 0, 0, 0);
+    return midnight;
 }
 
 function getNextModifiedDate(current: Date | null): Date {
@@ -102,9 +100,9 @@ export function collectRequestHandler(request: Request, env: Env) {
 
     const ifModifiedSince = request.headers.get("if-modified-since");
     const { newVisitor, newSession } = checkVisitorSession(ifModifiedSince);
-    const modifiedDate = ifModifiedSince
-        ? getNextModifiedDate(new Date(ifModifiedSince))
-        : getNextModifiedDate(null);
+    const modifiedDate = getNextModifiedDate(
+        ifModifiedSince ? new Date(ifModifiedSince) : null,
+    );
 
     const data: DataPoint = {
         siteId: params.sid,

--- a/app/analytics/query.ts
+++ b/app/analytics/query.ts
@@ -686,16 +686,21 @@ export class AnalyticsEngineAPI {
 
                 const data = responseData.data;
 
-                const earliestEvent = data.filter(
+                const earliestEvent = data.find(
                     (row) => row["isBounce"] === 0,
-                )[0]["earliestEvent"];
-                const earliestBounce = data.filter(
+                )?.earliestEvent;
+
+                const earliestBounce = data.find(
                     (row) => row["isBounce"] === 1,
-                )[0]["earliestEvent"];
+                )?.earliestEvent;
 
                 resolve({
-                    earliestEvent: new Date(earliestEvent),
-                    earliestBounce: new Date(earliestBounce),
+                    earliestEvent: earliestEvent
+                        ? new Date(earliestEvent)
+                        : null,
+                    earliestBounce: earliestBounce
+                        ? new Date(earliestBounce)
+                        : null,
                 });
             })();
         });

--- a/app/analytics/query.ts
+++ b/app/analytics/query.ts
@@ -34,7 +34,7 @@ function accumulateCountsFromRowResult(
         count: number;
         isVisitor: number;
         isVisit: number;
-        bounce: number;
+        isBounce: number;
     },
 ) {
     if (row.isVisit == 1) {
@@ -43,9 +43,9 @@ function accumulateCountsFromRowResult(
     if (row.isVisitor == 1) {
         counts.visitors += Number(row.count);
     }
-    if (row.bounce && row.bounce != 0) {
+    if (row.isBounce && row.isBounce != 0) {
         // bounce is either 1 or -1
-        counts.bounces += Number(row.count) * row.bounce;
+        counts.bounces += Number(row.count) * row.isBounce;
     }
     counts.views += Number(row.count);
 }
@@ -310,19 +310,19 @@ export class AnalyticsEngineAPI {
             SELECT SUM(_sample_interval) as count,
                 ${ColumnMappings.newVisitor} as isVisitor,
                 ${ColumnMappings.newSession} as isVisit,
-                ${ColumnMappings.bounce} as bounce
+                ${ColumnMappings.bounce} as isBounce
             FROM metricsDataset
             WHERE timestamp >= ${startIntervalSql} AND timestamp < ${endIntervalSql}
                 ${filterStr}
             AND ${siteIdColumn} = '${siteId}'
-            GROUP BY isVisitor, isVisit, bounce
-            ORDER BY isVisitor, isVisit, bounce ASC`;
+            GROUP BY isVisitor, isVisit, isBounce
+            ORDER BY isVisitor, isVisit, isBounce ASC`;
 
         type SelectionSet = {
             count: number;
             isVisitor: number;
             isVisit: number;
-            bounce: number;
+            isBounce: number;
         };
 
         const queryResult = this.query(query);
@@ -446,7 +446,7 @@ export class AnalyticsEngineAPI {
             SELECT ${_column},
                 ${ColumnMappings.newVisitor} as isVisitor,
                 ${ColumnMappings.newSession} as isVisit,
-                ${ColumnMappings.bounce} as bounce,
+                ${ColumnMappings.bounce} as isBounce,
                 SUM(_sample_interval) as count
             FROM metricsDataset
             WHERE timestamp >= ${startIntervalSql} AND timestamp < ${endIntervalSql}
@@ -460,7 +460,7 @@ export class AnalyticsEngineAPI {
             readonly count: number;
             readonly isVisitor: number;
             readonly isVisit: number;
-            readonly bounce: number;
+            readonly isBounce: number;
         } & Record<
             (typeof ColumnMappings)[T],
             ColumnMappingToType<(typeof ColumnMappings)[T]>

--- a/app/analytics/query.ts
+++ b/app/analytics/query.ts
@@ -25,7 +25,7 @@ interface AnalyticsCountResult {
 }
 
 /** Given an AnalyticsCountResult object, and an object representing a row returned from
- *  CF Analytics Engine w/ counts grouped by isVisitor and isVisit, accumulate view,
+ *  CF Analytics Engine w/ counts grouped by isVisitor, isVisit, and isBounce, accumulate view,
  *  visit, and visitor counts.
  */
 function accumulateCountsFromRowResult(
@@ -34,7 +34,7 @@ function accumulateCountsFromRowResult(
         count: number;
         isVisitor: number;
         isVisit: number;
-        bounce: number;
+        isBounce: number;
     },
 ) {
     if (row.isVisit == 1) {
@@ -43,9 +43,8 @@ function accumulateCountsFromRowResult(
     if (row.isVisitor == 1) {
         counts.visitors += Number(row.count);
     }
-    if (row.bounce && row.bounce != 0) {
-        // bounce is either 1 or -1
-        counts.bounces += Number(row.count) * row.bounce;
+    if (row.isBounce == 1 || row.isBounce == -1) {
+        counts.bounces += Number(row.count) * row.isBounce;
     }
     counts.views += Number(row.count);
 }
@@ -310,19 +309,19 @@ export class AnalyticsEngineAPI {
             SELECT SUM(_sample_interval) as count,
                 ${ColumnMappings.newVisitor} as isVisitor,
                 ${ColumnMappings.newSession} as isVisit,
-                ${ColumnMappings.bounce} as bounce
+                ${ColumnMappings.bounce} as isBounce
             FROM metricsDataset
             WHERE timestamp >= ${startIntervalSql} AND timestamp < ${endIntervalSql}
                 ${filterStr}
             AND ${siteIdColumn} = '${siteId}'
-            GROUP BY isVisitor, isVisit, bounce
-            ORDER BY isVisitor, isVisit, bounce ASC`;
+            GROUP BY isVisitor, isVisit, isBounce
+            ORDER BY isVisitor, isVisit, isBounce ASC`;
 
         type SelectionSet = {
             count: number;
             isVisitor: number;
             isVisit: number;
-            bounce: number;
+            isBounce: number;
         };
 
         const queryResult = this.query(query);
@@ -446,7 +445,7 @@ export class AnalyticsEngineAPI {
             SELECT ${_column},
                 ${ColumnMappings.newVisitor} as isVisitor,
                 ${ColumnMappings.newSession} as isVisit,
-                ${ColumnMappings.bounce} as bounce,
+                ${ColumnMappings.bounce} as isBounce,
                 SUM(_sample_interval) as count
             FROM metricsDataset
             WHERE timestamp >= ${startIntervalSql} AND timestamp < ${endIntervalSql}
@@ -460,7 +459,7 @@ export class AnalyticsEngineAPI {
             readonly count: number;
             readonly isVisitor: number;
             readonly isVisit: number;
-            readonly bounce: number;
+            readonly isBounce: number;
         } & Record<
             (typeof ColumnMappings)[T],
             ColumnMappingToType<(typeof ColumnMappings)[T]>

--- a/app/analytics/schema.ts
+++ b/app/analytics/schema.ts
@@ -32,4 +32,7 @@ export const ColumnMappings = {
 
     // this record is a new session (resets after 30m inactivity)
     newSession: "double2",
+
+    // this record is the bounce value
+    bounce: "double3",
 } as const;

--- a/app/routes/__tests__/dashboard.test.tsx
+++ b/app/routes/__tests__/dashboard.test.tsx
@@ -217,7 +217,6 @@ describe("Dashboard route", () => {
                         loader: () => {
                             return json({
                                 views: 0,
-                                visits: 0,
                                 visitors: 0,
                             });
                         },
@@ -270,7 +269,6 @@ describe("Dashboard route", () => {
         siteId: "example",
         sites: ["example"],
         views: 2133,
-        visits: 80,
         visitors: 33,
         viewsGroupedByInterval: [
             ["2024-01-11 05:00:00", 0],
@@ -304,7 +302,6 @@ describe("Dashboard route", () => {
                         loader: () => {
                             return json({
                                 views: 2133,
-                                visits: 80,
                                 visitors: 33,
                             });
                         },

--- a/app/routes/__tests__/resources.stats.test.tsx
+++ b/app/routes/__tests__/resources.stats.test.tsx
@@ -5,7 +5,6 @@ describe("resources.stats loader", () => {
     test("returns formatted stats from analytics engine", async () => {
         const mockGetCounts = vi.fn().mockResolvedValue({
             views: 1000,
-            visits: 500,
             visitors: 250,
         });
 
@@ -31,7 +30,6 @@ describe("resources.stats loader", () => {
 
         expect(data).toEqual({
             views: 1000,
-            visits: 500,
             visitors: 250,
         });
     });

--- a/app/routes/__tests__/resources.stats.test.tsx
+++ b/app/routes/__tests__/resources.stats.test.tsx
@@ -1,16 +1,33 @@
-import { describe, test, expect, vi } from "vitest";
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
 import { loader } from "../resources.stats";
 
 describe("resources.stats loader", () => {
-    test("returns formatted stats from analytics engine", async () => {
-        const mockGetCounts = vi.fn().mockResolvedValue({
+    let mockGetCounts: any;
+    beforeEach(() => {
+        mockGetCounts = vi.fn().mockResolvedValue({
             views: 1000,
             visitors: 250,
+            bounces: 125,
+        });
+    });
+
+    afterEach(() => {
+        vi.resetAllMocks();
+    });
+
+    test("returns formatted stats from analytics engine", async () => {
+        vi.setSystemTime(new Date("2023-01-01T06:00:00").getTime());
+
+        const mockGetEarliestEvents = vi.fn().mockResolvedValue({
+            // earliest event and earliest bounce are the same
+            earliestEvent: new Date("2023-01-01T00:00:00Z"),
+            earliestBounce: new Date("2023-01-01T00:00:00Z"),
         });
 
         const context = {
             analyticsEngine: {
                 getCounts: mockGetCounts,
+                getEarliestEvents: mockGetEarliestEvents,
             },
         };
 
@@ -31,6 +48,69 @@ describe("resources.stats loader", () => {
         expect(data).toEqual({
             views: 1000,
             visitors: 250,
+            bounceRate: "50%",
+        });
+    });
+
+    test("if bounce data isn't complete for the given interval, show n/a", async () => {
+        // set system time as jan 8th
+        vi.setSystemTime(new Date("2023-01-08T00:00:00").getTime());
+
+        const mockGetEarliestEvents = vi.fn().mockResolvedValue({
+            earliestEvent: new Date("2023-01-01T00:00:00Z"),
+            earliestBounce: new Date("2023-01-04T00:00:00Z"), // Jan 4
+        });
+
+        const context = {
+            analyticsEngine: {
+                getCounts: mockGetCounts,
+                getEarliestEvents: mockGetEarliestEvents,
+            },
+        };
+
+        const request = new Request(
+            // 7 day interval (specified in query string)
+            "https://example.com/resources/stats?site=test-site&interval=7d&timezone=UTC",
+        );
+
+        const response = await loader({ context, request } as any);
+        const data = await response.json();
+
+        expect(data).toEqual({
+            views: 1000,
+            visitors: 250,
+            bounceRate: "n/a",
+        });
+    });
+
+    test("if bounce data *IS* complete for the given interval, show it", async () => {
+        // set system time as jan 8th
+        vi.setSystemTime(new Date("2023-01-08T00:00:00").getTime());
+
+        const mockGetEarliestEvents = vi.fn().mockResolvedValue({
+            earliestEvent: new Date("2023-01-01T00:00:00Z"),
+            earliestBounce: new Date("2023-01-04T00:00:00Z"), // Jan 4 -- well before Jan 8th minus 1 day interval
+        });
+
+        const context = {
+            analyticsEngine: {
+                getCounts: mockGetCounts,
+                getEarliestEvents: mockGetEarliestEvents,
+            },
+        };
+
+        const request = new Request(
+            // 1 day interval (specified in query string)
+            "https://example.com/resources/stats?site=test-site&interval=1d&timezone=UTC",
+        );
+
+        const response = await loader({ context, request } as any);
+        const data = await response.json();
+
+        expect(data).toEqual({
+            views: 1000,
+            visitors: 250,
+            bounceRate: "50%",
         });
     });
 });

--- a/app/routes/__tests__/resources.stats.test.tsx
+++ b/app/routes/__tests__/resources.stats.test.tsx
@@ -48,11 +48,12 @@ describe("resources.stats loader", () => {
         expect(data).toEqual({
             views: 1000,
             visitors: 250,
-            bounceRate: "50%",
+            bounceRate: 0.5,
+            hasSufficientBounceData: true,
         });
     });
 
-    test("if bounce data isn't complete for the given interval, show n/a", async () => {
+    test("if bounce data isn't complete for the given interval, hasSufficientBounceData is false", async () => {
         // set system time as jan 8th
         vi.setSystemTime(new Date("2023-01-08T00:00:00").getTime());
 
@@ -79,7 +80,8 @@ describe("resources.stats loader", () => {
         expect(data).toEqual({
             views: 1000,
             visitors: 250,
-            bounceRate: "n/a",
+            bounceRate: 0.5,
+            hasSufficientBounceData: false,
         });
     });
 
@@ -110,7 +112,8 @@ describe("resources.stats loader", () => {
         expect(data).toEqual({
             views: 1000,
             visitors: 250,
-            bounceRate: "50%",
+            bounceRate: 0.5,
+            hasSufficientBounceData: true,
         });
     });
 });

--- a/app/routes/resources.stats.tsx
+++ b/app/routes/resources.stats.tsx
@@ -19,6 +19,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
         views: counts.views,
         visits: counts.visits,
         visitors: counts.visitors,
+        bounces: counts.bounces,
     });
 }
 
@@ -35,7 +36,7 @@ export const StatsCard = ({
 }) => {
     const dataFetcher = useFetcher<typeof loader>();
 
-    const { views, visits, visitors } = dataFetcher.data || {};
+    const { views, visits, visitors, bounces } = dataFetcher.data || {};
     const countFormatter = Intl.NumberFormat("en", { notation: "compact" });
 
     useEffect(() => {
@@ -74,6 +75,12 @@ export const StatsCard = ({
                         <div className="text-md sm:text-lg">Visitors</div>
                         <div className="text-4xl">
                             {visitors ? countFormatter.format(visitors) : "-"}
+                        </div>
+                    </div>
+                    <div>
+                        <div className="text-md sm:text-lg">Bounces</div>
+                        <div className="text-4xl">
+                            {bounces ? countFormatter.format(bounces) : "-"}
                         </div>
                     </div>
                 </div>

--- a/app/routes/resources.stats.tsx
+++ b/app/routes/resources.stats.tsx
@@ -17,7 +17,6 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
 
     return json({
         views: counts.views,
-        visits: counts.visits,
         visitors: counts.visitors,
         bounces: counts.bounces,
     });
@@ -36,7 +35,7 @@ export const StatsCard = ({
 }) => {
     const dataFetcher = useFetcher<typeof loader>();
 
-    const { views, visits, visitors, bounces } = dataFetcher.data || {};
+    const { views, visitors, bounces } = dataFetcher.data || {};
     const countFormatter = Intl.NumberFormat("en", { notation: "compact" });
 
     useEffect(() => {
@@ -63,12 +62,6 @@ export const StatsCard = ({
                         <div className="text-md">Views</div>
                         <div className="text-4xl">
                             {views ? countFormatter.format(views) : "-"}
-                        </div>
-                    </div>
-                    <div>
-                        <div className="text-md sm:text-lg">Visits</div>
-                        <div className="text-4xl">
-                            {visits ? countFormatter.format(visits) : "-"}
                         </div>
                     </div>
                     <div>


### PR DESCRIPTION
## Description

Adds tracking of bounces to `collect.ts` and `query.ts`. The implementation follows the approach outlined in the article https://notes.normally.com/cookieless-unique-visitor-counts/. I modified the existing implementation in `collect.ts` a bit to actually increment the `Last-Modified` header by one second instead of putting the current time. This is closer to the implementation in the article and allows the code to dynamically calculate the visits and determine the bounce value. Once the bounce value is determined it is written by the analytics engine.

**Side note**: I did not want to touch the `checkVisitorSession` function but maybe it would be a good idea to merge this with the `getBounce` function?

In `query.ts` I updated the queries to also return the bounce value.

In `resources.stats.tsx` I updated the route to display the bounce value.

I have the changes deployed at: https://bounce-tracking.counterscale-7bi.pages.dev/dashboard?site=counterscale-dev

## Note

Hi Ben, I am a student from the University of Toronto and attended the guest lecture you held for CSCD01 for the Fall 2024 semester. One of the things you mentioned was that you are working on Counterscale. I got pretty interested and saw this issue which I thought I could tackle. I am new to the repository so I am not too sure if I did everything correctly and I may have missed some details but please let me know what you think when you get a chance! 

## Issue

This closes #47