### PR TITLE
Fix pagination in getAllCountsByColumn

### DIFF
--- a/app/analytics/query.ts
+++ b/app/analytics/query.ts
@@ -450,7 +450,7 @@ export class AnalyticsEngineAPI {
         const filterStr = filtersToSql(filters);
         const _column = ColumnMappings[column];
         const query = `
-            SELECT ${_column} as column,
+            SELECT ${_column},
                 ${ColumnMappings.newVisitor} as isVisitor,
                 SUM(_sample_interval) as count
             FROM metricsDataset
@@ -464,7 +464,6 @@ export class AnalyticsEngineAPI {
             LIMIT ${limit * page}`;
 
         type SelectionSet = {
-            column: string;
             count: number;
             isVisitor: number;
             isBounce: number;
@@ -497,7 +496,7 @@ export class AnalyticsEngineAPI {
                     // the query results (pageData)
                     visitorCountByColumn.forEach(([key, value]) => {
                         pageData.push({
-                            column: key,
+                            [_column]: key,
                             count: value,
                             isVisitor: 1,
                         } as SelectionSet);
@@ -505,7 +504,7 @@ export class AnalyticsEngineAPI {
 
                     const result = pageData.reduce(
                         (acc, row) => {
-                            const key = row["column"] as string;
+                            const key = row[_column] as string;
                             if (!Object.hasOwn(acc, key)) {
                                 acc[key] = {
                                     views: 0,

--- a/app/analytics/query.ts
+++ b/app/analytics/query.ts
@@ -430,26 +430,44 @@ export class AnalyticsEngineAPI {
             tz,
         );
 
-        const filterStr = filtersToSql(filters);
+        // first query by visitor count – this is to figure out the top N results
+        // by visitor count first
+        // NOTE: there's an await here; need to fix this or harms parallelism
+        const visitorCountByColumn = await this.getVisitorCountByColumn(
+            siteId,
+            column,
+            interval,
+            tz,
+            filters,
+            page,
+            limit,
+        );
 
+        // next, make a second query - this time for non-visitor hits - by filtering
+        // on the keys returned by the first query.
+        const keys = visitorCountByColumn.map(([key]) => key);
+
+        const filterStr = filtersToSql(filters);
         const _column = ColumnMappings[column];
         const query = `
-            SELECT ${_column},
+            SELECT ${_column} as column,
                 ${ColumnMappings.newVisitor} as isVisitor,
-                ${ColumnMappings.bounce} as isBounce,
                 SUM(_sample_interval) as count
             FROM metricsDataset
             WHERE timestamp >= ${startIntervalSql} AND timestamp < ${endIntervalSql}
+                AND ${_column} IN (${keys.map((key) => `'${key}'`).join(", ")})
+                AND ${ColumnMappings.newVisitor} = 0
                 AND ${ColumnMappings.siteId} = '${siteId}'
                 ${filterStr}
-            GROUP BY ${_column}, ${ColumnMappings.newVisitor}, ${ColumnMappings.bounce}
+            GROUP BY ${_column}, ${ColumnMappings.newVisitor}
             ORDER BY count DESC
             LIMIT ${limit * page}`;
 
         type SelectionSet = {
-            readonly count: number;
-            readonly isVisitor: number;
-            readonly isBounce: number;
+            column: string;
+            count: number;
+            isVisitor: number;
+            isBounce: number;
         } & Record<
             (typeof ColumnMappings)[T],
             ColumnMappingToType<(typeof ColumnMappings)[T]>
@@ -475,9 +493,19 @@ export class AnalyticsEngineAPI {
                         limit * page,
                     );
 
+                    // remap visitor counts into SelectionSet objects, then insert into
+                    // the query results (pageData)
+                    visitorCountByColumn.forEach(([key, value]) => {
+                        pageData.push({
+                            column: key,
+                            count: value,
+                            isVisitor: 1,
+                        } as SelectionSet);
+                    });
+
                     const result = pageData.reduce(
                         (acc, row) => {
-                            const key = row[_column] as string;
+                            const key = row["column"] as string;
                             if (!Object.hasOwn(acc, key)) {
                                 acc[key] = {
                                     views: 0,
@@ -491,6 +519,7 @@ export class AnalyticsEngineAPI {
                         },
                         {} as Record<string, AnalyticsCountResult>,
                     );
+
                     resolve(result);
                 })(),
         );

--- a/app/routes/__tests__/resources.paths.test.tsx
+++ b/app/routes/__tests__/resources.paths.test.tsx
@@ -25,29 +25,28 @@ describe("Resources/Paths route", () => {
     });
     describe("loader", () => {
         test("returns valid json", async () => {
+            // first request for visitors
             fetch.mockResolvedValueOnce(
                 createFetchResponse({
                     data: [
-                        { blob3: "/", isVisitor: 0, isVisit: 0, count: "5" },
-                        { blob3: "/", isVisitor: 0, isVisit: 1, count: "1" },
-                        { blob3: "/", isVisitor: 1, isVisit: 1, count: "2" },
-                        {
-                            blob3: "/example",
-                            isVisitor: 0,
-                            isVisit: 0,
-                            count: "4",
-                        },
-                        {
-                            blob3: "/example",
-                            isVisitor: 0,
-                            isVisit: 1,
-                            count: "6",
-                        },
+                        { blob3: "/", isVisitor: 1, count: "2" },
                         {
                             blob3: "/example",
                             isVisitor: 1,
-                            isVisit: 1,
-                            count: "2",
+                            count: "4",
+                        },
+                    ],
+                }),
+            );
+            // second request for views
+            fetch.mockResolvedValueOnce(
+                createFetchResponse({
+                    data: [
+                        { blob3: "/", isVisitor: 0, count: "5" },
+                        {
+                            blob3: "/example",
+                            isVisitor: 0,
+                            count: "6",
                         },
                     ],
                 }),
@@ -63,12 +62,14 @@ describe("Resources/Paths route", () => {
 
             // expect redirect
             expect(response.status).toBe(200);
+            expect(fetch).toHaveBeenCalledTimes(2);
 
             const json = await response.json();
+
             expect(json).toEqual({
                 countsByProperty: [
-                    ["/", 2, 8],
-                    ["/example", 2, 12],
+                    ["/example", 4, 10],
+                    ["/", 2, 7],
                 ],
                 page: 1,
             });

--- a/app/routes/__tests__/resources.referrer.test.tsx
+++ b/app/routes/__tests__/resources.referrer.test.tsx
@@ -26,22 +26,28 @@ describe("Resources/Referrer route", () => {
 
     describe("loader", () => {
         test("returns valid json", async () => {
+            // first request for visitors
             fetch.mockResolvedValueOnce(
                 createFetchResponse({
                     data: [
-                        { blob5: "/", isVisitor: 0, isVisit: 0, count: "5" },
-                        { blob5: "/", isVisitor: 1, isVisit: 1, count: "1" },
-                        {
-                            blob5: "/example",
-                            isVisitor: 0,
-                            isVisit: 1,
-                            count: "2",
-                        },
+                        { blob5: "/", isVisitor: 1, count: "1" },
                         {
                             blob5: "/example",
                             isVisitor: 1,
-                            isVisit: 1,
                             count: "1",
+                        },
+                    ],
+                }),
+            );
+            // second request for views
+            fetch.mockResolvedValueOnce(
+                createFetchResponse({
+                    data: [
+                        { blob5: "/", isVisitor: 0, count: "5" },
+                        {
+                            blob5: "/example",
+                            isVisitor: 0,
+                            count: "2",
                         },
                     ],
                 }),
@@ -57,6 +63,7 @@ describe("Resources/Referrer route", () => {
 
             // expect redirect
             expect(response.status).toBe(200);
+            expect(fetch).toHaveBeenCalledTimes(2);
 
             const json = await response.json();
             expect(json).toEqual({


### PR DESCRIPTION
Fixes #122

I realize now getAllCountsByColumn had flawed logic; it was trying to get the top N rows, but also trying to simultaneously get data for visitors and views which doesn't work because that needs 2x the rows, and the `count` properties might not return in the same order either.

So instead this makes two queries:

1. First, queries the column by visitor count. This first query determines the order (so the rows are sorted by visitor count, not view count).

2. Then, make another query by _view_ count, using a `WHERE $column IN ($columnVal1, $columnVal1, ... $columnVal1)` clause from the results of the first query.

This is slower of course, but it seems unavoidable the way Analytics Engine works.