### PR TITLE
Add visitors + bounce rate to timeseries chart

### DIFF
--- a/app/analytics/__tests__/query.test.ts
+++ b/app/analytics/__tests__/query.test.ts
@@ -93,14 +93,14 @@ describe("AnalyticsEngineAPI", () => {
             // results should all be at 05:00:00 because local timezone is UTC-5 --
             // this set of results represents "start of day" in local tz, which is 5 AM UTC
             expect(result1).toEqual([
-                ["2024-01-11 05:00:00", 0],
-                ["2024-01-12 05:00:00", 0],
-                ["2024-01-13 05:00:00", 3],
-                ["2024-01-14 05:00:00", 0],
-                ["2024-01-15 05:00:00", 0],
-                ["2024-01-16 05:00:00", 2],
-                ["2024-01-17 05:00:00", 1],
-                ["2024-01-18 05:00:00", 0],
+                ["2024-01-11 05:00:00", { views: 0, visitors: 0, bounces: 0 }],
+                ["2024-01-12 05:00:00", { views: 0, visitors: 0, bounces: 0 }],
+                ["2024-01-13 05:00:00", { views: 3, visitors: 0, bounces: 0 }],
+                ["2024-01-14 05:00:00", { views: 0, visitors: 0, bounces: 0 }],
+                ["2024-01-15 05:00:00", { views: 0, visitors: 0, bounces: 0 }],
+                ["2024-01-16 05:00:00", { views: 2, visitors: 0, bounces: 0 }],
+                ["2024-01-17 05:00:00", { views: 1, visitors: 0, bounces: 0 }],
+                ["2024-01-18 05:00:00", { views: 0, visitors: 0, bounces: 0 }],
             ]);
 
             const result2 = await api.getViewsGroupedByInterval(
@@ -111,12 +111,12 @@ describe("AnalyticsEngineAPI", () => {
                 "America/New_York",
             );
             expect(result2).toEqual([
-                ["2024-01-13 05:00:00", 3],
-                ["2024-01-14 05:00:00", 0],
-                ["2024-01-15 05:00:00", 0],
-                ["2024-01-16 05:00:00", 2],
-                ["2024-01-17 05:00:00", 1],
-                ["2024-01-18 05:00:00", 0],
+                ["2024-01-13 05:00:00", { views: 3, visitors: 0, bounces: 0 }],
+                ["2024-01-14 05:00:00", { views: 0, visitors: 0, bounces: 0 }],
+                ["2024-01-15 05:00:00", { views: 0, visitors: 0, bounces: 0 }],
+                ["2024-01-16 05:00:00", { views: 2, visitors: 0, bounces: 0 }],
+                ["2024-01-17 05:00:00", { views: 1, visitors: 0, bounces: 0 }],
+                ["2024-01-18 05:00:00", { views: 0, visitors: 0, bounces: 0 }],
             ]);
         });
     });
@@ -129,15 +129,21 @@ describe("AnalyticsEngineAPI", () => {
                 data: [
                     {
                         count: 3,
+                        isVisitor: 0,
+                        isBounce: 0,
                         // note: intentionally sparse data (data for some timestamps missing)
                         bucket: "2024-01-17 11:00:00",
                     },
                     {
                         count: 2,
+                        isVisitor: 0,
+                        isBounce: 0,
                         bucket: "2024-01-17 14:00:00",
                     },
                     {
                         count: 1,
+                        isVisitor: 0,
+                        isBounce: 0,
                         bucket: "2024-01-17 16:00:00",
                     },
                 ],
@@ -158,31 +164,31 @@ describe("AnalyticsEngineAPI", () => {
         // so if we want the last 24 hours from 05:00:00 in local time (EST), the actual
         // time range in UTC starts and ends at 10:00:00 (+5 hours)
         expect(result1).toEqual([
-            ["2024-01-17 10:00:00", 0],
-            ["2024-01-17 11:00:00", 3],
-            ["2024-01-17 12:00:00", 0],
-            ["2024-01-17 13:00:00", 0],
-            ["2024-01-17 14:00:00", 2],
-            ["2024-01-17 15:00:00", 0],
-            ["2024-01-17 16:00:00", 1],
-            ["2024-01-17 17:00:00", 0],
-            ["2024-01-17 18:00:00", 0],
-            ["2024-01-17 19:00:00", 0],
-            ["2024-01-17 20:00:00", 0],
-            ["2024-01-17 21:00:00", 0],
-            ["2024-01-17 22:00:00", 0],
-            ["2024-01-17 23:00:00", 0],
-            ["2024-01-18 00:00:00", 0],
-            ["2024-01-18 01:00:00", 0],
-            ["2024-01-18 02:00:00", 0],
-            ["2024-01-18 03:00:00", 0],
-            ["2024-01-18 04:00:00", 0],
-            ["2024-01-18 05:00:00", 0],
-            ["2024-01-18 06:00:00", 0],
-            ["2024-01-18 07:00:00", 0],
-            ["2024-01-18 08:00:00", 0],
-            ["2024-01-18 09:00:00", 0],
-            ["2024-01-18 10:00:00", 0],
+            ["2024-01-17 10:00:00", { views: 0, visitors: 0, bounces: 0 }],
+            ["2024-01-17 11:00:00", { views: 3, visitors: 0, bounces: 0 }],
+            ["2024-01-17 12:00:00", { views: 0, visitors: 0, bounces: 0 }],
+            ["2024-01-17 13:00:00", { views: 0, visitors: 0, bounces: 0 }],
+            ["2024-01-17 14:00:00", { views: 2, visitors: 0, bounces: 0 }],
+            ["2024-01-17 15:00:00", { views: 0, visitors: 0, bounces: 0 }],
+            ["2024-01-17 16:00:00", { views: 1, visitors: 0, bounces: 0 }],
+            ["2024-01-17 17:00:00", { views: 0, visitors: 0, bounces: 0 }],
+            ["2024-01-17 18:00:00", { views: 0, visitors: 0, bounces: 0 }],
+            ["2024-01-17 19:00:00", { views: 0, visitors: 0, bounces: 0 }],
+            ["2024-01-17 20:00:00", { views: 0, visitors: 0, bounces: 0 }],
+            ["2024-01-17 21:00:00", { views: 0, visitors: 0, bounces: 0 }],
+            ["2024-01-17 22:00:00", { views: 0, visitors: 0, bounces: 0 }],
+            ["2024-01-17 23:00:00", { views: 0, visitors: 0, bounces: 0 }],
+            ["2024-01-18 00:00:00", { views: 0, visitors: 0, bounces: 0 }],
+            ["2024-01-18 01:00:00", { views: 0, visitors: 0, bounces: 0 }],
+            ["2024-01-18 02:00:00", { views: 0, visitors: 0, bounces: 0 }],
+            ["2024-01-18 03:00:00", { views: 0, visitors: 0, bounces: 0 }],
+            ["2024-01-18 04:00:00", { views: 0, visitors: 0, bounces: 0 }],
+            ["2024-01-18 05:00:00", { views: 0, visitors: 0, bounces: 0 }],
+            ["2024-01-18 06:00:00", { views: 0, visitors: 0, bounces: 0 }],
+            ["2024-01-18 07:00:00", { views: 0, visitors: 0, bounces: 0 }],
+            ["2024-01-18 08:00:00", { views: 0, visitors: 0, bounces: 0 }],
+            ["2024-01-18 09:00:00", { views: 0, visitors: 0, bounces: 0 }],
+            ["2024-01-18 10:00:00", { views: 0, visitors: 0, bounces: 0 }],
         ]);
     });
 

--- a/app/analytics/query.ts
+++ b/app/analytics/query.ts
@@ -271,7 +271,7 @@ export class AnalyticsEngineAPI {
                             const key = dayjs(utcDateTime).format(
                                 "YYYY-MM-DD HH:mm:ss",
                             );
-                            if (!accum.hasOwnProperty(key)) {
+                            if (!Object.hasOwn(accum, key)) {
                                 accum[key] = {
                                     views: 0,
                                     visitors: 0,

--- a/app/components/TimeSeriesChart.tsx
+++ b/app/components/TimeSeriesChart.tsx
@@ -1,5 +1,3 @@
-import PropTypes, { InferProps } from "prop-types";
-
 import {
     AreaChart,
     Area,
@@ -10,11 +8,22 @@ import {
     ResponsiveContainer,
 } from "recharts";
 
+interface TimeSeriesChartProps {
+    data: Array<{
+        date: string;
+        views: number;
+        visitors: number;
+        bounces: number;
+    }>;
+    intervalType?: string;
+    timezone?: string;
+}
+
 export default function TimeSeriesChart({
     data,
     intervalType,
     timezone,
-}: InferProps<typeof TimeSeriesChart.propTypes>) {
+}: TimeSeriesChartProps) {
     // chart doesn't really work no data points, so just bail out
     if (data.length === 0) {
         return null;
@@ -88,17 +97,13 @@ export default function TimeSeriesChart({
                     strokeWidth="2"
                     fill="#F99C35"
                 />
+                <Area
+                    dataKey="visitors"
+                    stroke="#F46A3D"
+                    strokeWidth="2"
+                    fill="#f96d3e"
+                />
             </AreaChart>
         </ResponsiveContainer>
     );
 }
-
-TimeSeriesChart.propTypes = {
-    data: PropTypes.arrayOf(
-        PropTypes.shape({
-            views: PropTypes.number.isRequired,
-        }).isRequired,
-    ).isRequired,
-    intervalType: PropTypes.string,
-    timezone: PropTypes.string,
-};

--- a/app/components/TimeSeriesChart.tsx
+++ b/app/components/TimeSeriesChart.tsx
@@ -1,11 +1,12 @@
 import {
-    AreaChart,
+    Line,
     Area,
     XAxis,
     YAxis,
     CartesianGrid,
     Tooltip,
     ResponsiveContainer,
+    ComposedChart,
 } from "recharts";
 
 interface TimeSeriesChartProps {
@@ -13,7 +14,7 @@ interface TimeSeriesChartProps {
         date: string;
         views: number;
         visitors: number;
-        bounces: number;
+        bounceRate: number;
     }>;
     intervalType?: string;
     timezone?: string;
@@ -28,6 +29,8 @@ export default function TimeSeriesChart({
     if (data.length === 0) {
         return null;
     }
+
+    const MAX_Y_VALUE_MULTIPLIER = 1.2;
 
     // get the max integer value of data views
     const maxViews = Math.max(...data.map((item) => item.views));
@@ -74,7 +77,7 @@ export default function TimeSeriesChart({
 
     return (
         <ResponsiveContainer width="100%" height="100%" minWidth={100}>
-            <AreaChart
+            <ComposedChart
                 width={500}
                 height={400}
                 data={data}
@@ -89,21 +92,41 @@ export default function TimeSeriesChart({
                 <XAxis dataKey="date" tickFormatter={xAxisDateFormatter} />
 
                 {/* manually setting maxViews vs using recharts "dataMax" key cause it doesnt seem to work */}
-                <YAxis dataKey="views" domain={[0, maxViews]} />
+                <YAxis
+                    yAxisId="count"
+                    dataKey="views"
+                    domain={[0, Math.floor(maxViews * MAX_Y_VALUE_MULTIPLIER)]} // set max Y value a little higher than what was recorded
+                />
+                <YAxis
+                    yAxisId="bounceRate"
+                    dataKey="bounceRate"
+                    domain={[0, Math.floor(100 * MAX_Y_VALUE_MULTIPLIER)]}
+                    hide={true}
+                />
+
                 <Tooltip labelFormatter={tooltipDateFormatter} />
                 <Area
+                    yAxisId="count"
                     dataKey="views"
                     stroke="#F46A3D"
                     strokeWidth="2"
                     fill="#F99C35"
                 />
                 <Area
+                    yAxisId="count"
                     dataKey="visitors"
                     stroke="#F46A3D"
                     strokeWidth="2"
                     fill="#f96d3e"
                 />
-            </AreaChart>
+                <Line
+                    yAxisId="bounceRate"
+                    dataKey="bounceRate"
+                    stroke="#56726C"
+                    strokeWidth="2"
+                    dot={false}
+                />
+            </ComposedChart>
         </ResponsiveContainer>
     );
 }

--- a/app/routes/__tests__/resources.timeseries.test.tsx
+++ b/app/routes/__tests__/resources.timeseries.test.tsx
@@ -25,8 +25,8 @@ describe("resources.timeseries loader", () => {
             context.analyticsEngine,
             "getViewsGroupedByInterval",
         ).mockResolvedValue([
-            ["2024-01-15T00:00:00Z", 100],
-            ["2024-01-16T00:00:00Z", 200],
+            ["2024-01-15T00:00:00Z", { views: 100, visitors: 0, bounces: 0 }],
+            ["2024-01-16T00:00:00Z", { views: 200, visitors: 0, bounces: 0 }],
         ]);
 
         // mock out responsive container to just return a standard div, otherwise
@@ -60,8 +60,18 @@ describe("resources.timeseries loader", () => {
 
         const data = await result.json();
         expect(data.chartData).toEqual([
-            { date: "2024-01-15T00:00:00Z", views: 100 },
-            { date: "2024-01-16T00:00:00Z", views: 200 },
+            {
+                date: "2024-01-15T00:00:00Z",
+                views: 100,
+                visitors: 0,
+                bounces: 0,
+            },
+            {
+                date: "2024-01-16T00:00:00Z",
+                views: 200,
+                visitors: 0,
+                bounces: 0,
+            },
         ]);
         expect(data.intervalType).toBe("DAY");
 

--- a/app/routes/__tests__/resources.timeseries.test.tsx
+++ b/app/routes/__tests__/resources.timeseries.test.tsx
@@ -64,13 +64,13 @@ describe("resources.timeseries loader", () => {
                 date: "2024-01-15T00:00:00Z",
                 views: 100,
                 visitors: 0,
-                bounces: 0,
+                bounceRate: 0,
             },
             {
                 date: "2024-01-16T00:00:00Z",
                 views: 200,
                 visitors: 0,
-                bounces: 0,
+                bounceRate: 0,
             },
         ]);
         expect(data.intervalType).toBe("DAY");
@@ -152,7 +152,10 @@ describe("TimeSeriesCard", () => {
         // Wait for the chart to be rendered
         await waitFor(() => screen.getAllByText("Mon, Jan 15").length > 0);
         // assert data appears in chart
-        expect(screen.getAllByText("100")).toHaveLength(2);
+
+        // 120 because 100 is max data point, then gets multiplied by 1.2 (MAX_Y_VALUE_MULTIPLIER)
+        // and this becomes a label in the chart
+        expect(screen.getAllByText("120")).toHaveLength(2);
     });
 
     test("refetches when props change", () => {

--- a/app/routes/resources.stats.tsx
+++ b/app/routes/resources.stats.tsx
@@ -96,6 +96,7 @@ export const StatsCard = ({
                             {visitors ? countFormatter.format(visitors) : "-"}
                         </div>
                     </div>
+
                     <div>
                         <div className="text-md sm:text-lg">Views</div>
                         <div className="text-4xl">

--- a/app/routes/resources.timeseries.tsx
+++ b/app/routes/resources.timeseries.tsx
@@ -36,12 +36,18 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
         date: string;
         views: number;
         visitors: number;
-        bounces: number;
+        bounceRate: number;
     }[] = [];
     viewsGroupedByInterval.forEach((row) => {
+        const { views, visitors, bounces } = row[1];
+
         chartData.push({
             date: row[0],
-            ...row[1],
+            views,
+            visitors,
+            bounceRate: Math.floor(
+                (visitors > 0 ? bounces / visitors : 0) * 100,
+            ),
         });
     });
 

--- a/app/routes/resources.timeseries.tsx
+++ b/app/routes/resources.timeseries.tsx
@@ -32,11 +32,16 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
             filters,
         );
 
-    const chartData: { date: string; views: number }[] = [];
+    const chartData: {
+        date: string;
+        views: number;
+        visitors: number;
+        bounces: number;
+    }[] = [];
     viewsGroupedByInterval.forEach((row) => {
         chartData.push({
             date: row[0],
-            views: row[1],
+            ...row[1],
         });
     });
 


### PR DESCRIPTION
Now that bounce data is available via #116, decided to add this and visitors to the timeseries chart.

Screenshot:

![image](https://github.com/user-attachments/assets/97bac174-d9e1-43a3-af12-d20f2e9b6ac7)
