### PR TITLE
Return proper Response object in Pages function

### DIFF
--- a/packages/server/functions/collect.ts
+++ b/packages/server/functions/collect.ts
@@ -10,13 +10,5 @@ export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
 
     // Similarly, convert Response to Cloudflare Response type by adding
     // webSocket property
-    const response = collectRequestHandler(
-        _request,
-        env,
-    ) as unknown as CfResponse;
-
-    return {
-        ...response,
-        webSocket: null,
-    } as CfResponse;
+    return collectRequestHandler(_request, env) as unknown as CfResponse;
 };


### PR DESCRIPTION
When converting to React Router 7, while trying to address some TypeScript typing issues, I made the mistake of not returning a proper `Response` object in the `/collect` Pages handler.

This meant that `/collect` was 1) writing the data, but 2) returning a 500 afterwards, which likely led to a host of issues like not setting `If-Modified-Since` headers properly (refs #148). This bug didn't appear in tests, nor using the Vite development server, which I mostly use for local development.

This highlights how the Pages function handlers need to be covered by tests, but on the flip side, they're being removed on the `v3` branch underway.

