### PR TITLE
Remove Electron early return

### DIFF
--- a/packages/tracker/src/lib/track.ts
+++ b/packages/tracker/src/lib/track.ts
@@ -52,7 +52,8 @@ export function trackPageview(client: Client, opts: TrackPageviewOpts = {}) {
     const canonical = getCanonicalUrl();
     const location = canonical ?? window.location;
 
-    if (location.host === "" && navigator.userAgent.indexOf("Electron") < 0) {
+    // if no valid hostname (e.g. serving from local filesystem), bail out
+    if (location.host === "") {
         return;
     }
 


### PR DESCRIPTION
I don't know of a good reason to have this. Out of mild curious, I checked the Plausible tracker source code and saw no comparable clause.

Fixes #152 