### PR TITLE
Reject blank site IDs (fixes #150)

### DIFF
--- a/packages/server/app/analytics/__tests__/collect.test.ts
+++ b/packages/server/app/analytics/__tests__/collect.test.ts
@@ -36,6 +36,59 @@ function generateRequestParams(headers: Record<string, string>) {
 }
 
 describe("collectRequestHandler", () => {
+    test("returns 400 when siteId is missing", () => {
+        const env = {
+            WEB_COUNTER_AE: {
+                writeDataPoint: vi.fn(),
+            } as AnalyticsEngineDataset,
+        } as Env;
+
+        const request = generateRequestParams({
+            "user-agent":
+                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
+        });
+        request.url =
+            "https://example.com/user/42?" +
+            new URLSearchParams({
+                h: "example.com",
+                p: "/post/123",
+                r: "https://google.com",
+                nv: "1",
+                ns: "1",
+            }).toString();
+
+        const response = collectRequestHandler(request as any, env);
+        expect(response.status).toBe(400);
+        expect(env.WEB_COUNTER_AE.writeDataPoint).not.toHaveBeenCalled();
+    });
+
+    test("returns 400 when siteId is empty string", () => {
+        const env = {
+            WEB_COUNTER_AE: {
+                writeDataPoint: vi.fn(),
+            } as AnalyticsEngineDataset,
+        } as Env;
+
+        const request = generateRequestParams({
+            "user-agent":
+                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
+        });
+        request.url =
+            "https://example.com/user/42?" +
+            new URLSearchParams({
+                sid: "",
+                h: "example.com",
+                p: "/post/123",
+                r: "https://google.com",
+                nv: "1",
+                ns: "1",
+            }).toString();
+
+        const response = collectRequestHandler(request as any, env);
+        expect(response.status).toBe(400);
+        expect(env.WEB_COUNTER_AE.writeDataPoint).not.toHaveBeenCalled();
+    });
+
     beforeEach(() => {
         // default time is just middle of the day
         vi.setSystemTime(new Date("2024-01-18T09:33:02").getTime());

--- a/packages/server/app/analytics/collect.ts
+++ b/packages/server/app/analytics/collect.ts
@@ -92,6 +92,11 @@ function extractParamsFromQueryString(requestUrl: string): {
 export function collectRequestHandler(request: Request, env: Env) {
     const params = extractParamsFromQueryString(request.url);
 
+    const siteId = params.sid;
+    if (!siteId || siteId === "") {
+        return new Response("Missing siteId", { status: 400 });
+    }
+
     const userAgent = request.headers.get("user-agent") || undefined;
     const parsedUserAgent = new UAParser(userAgent);
 
@@ -108,7 +113,7 @@ export function collectRequestHandler(request: Request, env: Env) {
     );
 
     const data: DataPoint = {
-        siteId: params.sid,
+        siteId,
         host: params.h,
         path: params.p,
         referrer: params.r,


### PR DESCRIPTION
There are browser plugins [that strip the query string](https://addons.mozilla.org/en-US/firefox/addon/clearurls/) from some URLs. They're used by a small minority of browser users, but just a few stripped requests can cause blank data to enter Counterscale instances, causing issues like #150.

This PR amends the collect handler to reject blank/empty string values for `sid`, and returns a 400 instead.

cc @tycobrah