### PR TITLE
fix: Country column not populating (fixes #166)

### DIFF
--- a/packages/server/app/analytics/__tests__/collect.test.ts
+++ b/packages/server/app/analytics/__tests__/collect.test.ts
@@ -104,7 +104,9 @@ describe("collectRequestHandler", () => {
         // @ts-expect-error - we're mocking the request object
         const request = httpMocks.createRequest(defaultRequestParams);
 
-        collectRequestHandler(request as any, env);
+        collectRequestHandler(request as any, env, {
+            country: "US",
+        });
 
         const writeDataPoint = env.WEB_COUNTER_AE.writeDataPoint;
         expect(env.WEB_COUNTER_AE.writeDataPoint).toHaveBeenCalled();

--- a/packages/server/app/analytics/collect.ts
+++ b/packages/server/app/analytics/collect.ts
@@ -1,7 +1,4 @@
-import type {
-    RequestInit,
-    AnalyticsEngineDataset,
-} from "@cloudflare/workers-types";
+import type { AnalyticsEngineDataset } from "@cloudflare/workers-types";
 import { UAParser } from "ua-parser-js";
 import { maskBrowserVersion } from "~/lib/utils";
 
@@ -89,7 +86,11 @@ function extractParamsFromQueryString(requestUrl: string): {
     return params;
 }
 
-export function collectRequestHandler(request: Request, env: Env) {
+export function collectRequestHandler(
+    request: Request,
+    env: Env,
+    extra: Record<string, string> = {}, // extra request properties (i.e. Cloudflare properties)
+) {
     const params = extractParamsFromQueryString(request.url);
 
     const siteId = params.sid;
@@ -127,7 +128,7 @@ export function collectRequestHandler(request: Request, env: Env) {
 
     // NOTE: location is derived from Cloudflare-specific request properties
     // see: https://developers.cloudflare.com/workers/runtime-apis/request/#incomingrequestcfproperties
-    const country = (request as RequestInit).cf?.country;
+    const country = extra?.country;
     if (typeof country === "string") {
         data.country = country;
     }

--- a/packages/server/app/entry.server.tsx
+++ b/packages/server/app/entry.server.tsx
@@ -21,6 +21,7 @@ export default async function handleRequest(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     loadContext: AppLoadContext,
 ) {
+    console.log(loadContext);
     const body = await renderToReadableStream(
         <ServerRouter context={reactRouterContext} url={request.url} />,
         {

--- a/packages/server/app/routes/collect.tsx
+++ b/packages/server/app/routes/collect.tsx
@@ -6,5 +6,9 @@ import { collectRequestHandler } from "~/analytics/collect";
 //       On Cloudflare Pages, the entry point is found in functions/collect.ts
 
 export async function loader({ request, context }: LoaderFunctionArgs) {
-    return collectRequestHandler(request, context.cloudflare.env);
+    return collectRequestHandler(
+        request,
+        context.cloudflare.env,
+        context.cloudflare.cf,
+    );
 }


### PR DESCRIPTION
This bug was introduced in v3.0.0-beta.1 as part of the migration from Cloudflare Pages to Cloudflare Workers. The `cf` property was not populated, and as a result this failed silently / just dropped data.