### PR TITLE
feat: Use device type instead of model for Device card

### DIFF
--- a/packages/server/app/analytics/__tests__/collect.test.ts
+++ b/packages/server/app/analytics/__tests__/collect.test.ts
@@ -123,6 +123,7 @@ describe("collectRequestHandler", () => {
                 "",
                 "example", // site id
                 "51.x.x.x", // browser version
+                "Desktop", // device type
             ],
             doubles: [
                 1, // new visitor

--- a/packages/server/app/analytics/__tests__/collect.test.ts
+++ b/packages/server/app/analytics/__tests__/collect.test.ts
@@ -123,7 +123,7 @@ describe("collectRequestHandler", () => {
                 "",
                 "example", // site id
                 "51.x.x.x", // browser version
-                "Desktop", // device type
+                "desktop", // device type
             ],
             doubles: [
                 1, // new visitor

--- a/packages/server/app/analytics/collect.ts
+++ b/packages/server/app/analytics/collect.ts
@@ -88,7 +88,7 @@ function extractParamsFromQueryString(requestUrl: string): {
 
 function getDeviceTypeFromDevice(device: IDevice): string {
     // see: https://github.com/faisalman/ua-parser-js/issues/182
-    return device.type === undefined ? "Desktop" : device.type;
+    return device.type === undefined ? "desktop" : device.type;
 }
 
 export function collectRequestHandler(

--- a/packages/server/app/analytics/collect.ts
+++ b/packages/server/app/analytics/collect.ts
@@ -1,5 +1,5 @@
 import type { AnalyticsEngineDataset } from "@cloudflare/workers-types";
-import { UAParser } from "ua-parser-js";
+import { IDevice, UAParser } from "ua-parser-js";
 import { maskBrowserVersion } from "~/lib/utils";
 
 // Cookieless visitor/session tracking
@@ -86,6 +86,11 @@ function extractParamsFromQueryString(requestUrl: string): {
     return params;
 }
 
+function getDeviceTypeFromDevice(device: IDevice): string {
+    // see: https://github.com/faisalman/ua-parser-js/issues/182
+    return device.type === undefined ? "Desktop" : device.type;
+}
+
 export function collectRequestHandler(
     request: Request,
     env: Env,
@@ -99,6 +104,7 @@ export function collectRequestHandler(
     }
 
     const userAgent = request.headers.get("user-agent") || undefined;
+
     const parsedUserAgent = new UAParser(userAgent);
 
     const ifModifiedSince = request.headers.get("if-modified-since");
@@ -124,6 +130,7 @@ export function collectRequestHandler(
         browserName: parsedUserAgent.getBrowser().name,
         browserVersion: browserVersion,
         deviceModel: parsedUserAgent.getDevice().model,
+        deviceType: getDeviceTypeFromDevice(parsedUserAgent.getDevice()),
     };
 
     // NOTE: location is derived from Cloudflare-specific request properties
@@ -172,6 +179,7 @@ interface DataPoint {
     browserName?: string;
     browserVersion?: string;
     deviceModel?: string;
+    deviceType?: string;
 
     // doubles
     newVisitor: number;
@@ -198,6 +206,7 @@ export function writeDataPoint(
             data.deviceModel || "", // blob7
             data.siteId || "", // blob8
             data.browserVersion || "", // blob9
+            data.deviceType || "", // blob10
         ],
         doubles: [data.newVisitor || 0, data.newSession || 0, data.bounce],
     };
@@ -205,6 +214,7 @@ export function writeDataPoint(
     if (!analyticsEngine) {
         // no-op
         console.log("Can't save datapoint: Analytics unavailable");
+        console.dir(datapoint, { depth: null });
         return;
     }
 

--- a/packages/server/app/analytics/query.ts
+++ b/packages/server/app/analytics/query.ts
@@ -672,7 +672,7 @@ export class AnalyticsEngineAPI {
         );
     }
 
-    async getCountByDevice(
+    async getCountByDeviceModel(
         siteId: string,
         interval: string,
         tz?: string,
@@ -682,6 +682,23 @@ export class AnalyticsEngineAPI {
         return this.getVisitorCountByColumn(
             siteId,
             "deviceModel",
+            interval,
+            tz,
+            filters,
+            page,
+        );
+    }
+
+    async getCountByDeviceType(
+        siteId: string,
+        interval: string,
+        tz?: string,
+        filters: SearchFilters = {},
+        page: number = 1,
+    ): Promise<[deviceType: string, visitors: number][]> {
+        return this.getVisitorCountByColumn(
+            siteId,
+            "deviceType",
             interval,
             tz,
             filters,

--- a/packages/server/app/analytics/schema.ts
+++ b/packages/server/app/analytics/schema.ts
@@ -23,6 +23,7 @@ export const ColumnMappings = {
     deviceModel: "blob7",
     siteId: "blob8",
     browserVersion: "blob9",
+    deviceType: "blob10",
 
     /**
      * doubles

--- a/packages/server/app/components/PaginatedTableCard.tsx
+++ b/packages/server/app/components/PaginatedTableCard.tsx
@@ -14,6 +14,7 @@ interface PaginatedTableCardProps {
     loaderUrl: string;
     onClick?: (key: string) => void;
     timezone?: string;
+    labelFormatter?: (label: string) => string;
 }
 
 const PaginatedTableCard = ({
@@ -25,6 +26,7 @@ const PaginatedTableCard = ({
     loaderUrl,
     onClick,
     timezone,
+    labelFormatter,
 }: PaginatedTableCardProps) => {
     const countsByProperty = dataFetcher.data?.countsByProperty || [];
     const [page, setPage] = useState(1);
@@ -59,6 +61,7 @@ const PaginatedTableCard = ({
                         countByProperty={countsByProperty}
                         columnHeaders={columnHeaders}
                         onClick={onClick}
+                        labelFormatter={labelFormatter}
                     />
                     <PaginationButtons
                         page={page}

--- a/packages/server/app/components/TableCard.tsx
+++ b/packages/server/app/components/TableCard.tsx
@@ -25,10 +25,12 @@ export default function TableCard({
     countByProperty,
     columnHeaders,
     onClick,
+    labelFormatter,
 }: {
     countByProperty: CountByProperty;
     columnHeaders: string[];
     onClick?: (key: string) => void;
+    labelFormatter?: (label: string) => string;
 }) {
     const barChartPercentages = calculateCountPercentages(countByProperty);
 
@@ -67,6 +69,11 @@ export default function TableCard({
                         ? [desc[0], desc[1] || "(unknown)"]
                         : [desc, desc || "(unknown)"];
 
+                    const formattedLabel =
+                        labelFormatter && typeof label === "string"
+                            ? labelFormatter(label)
+                            : label;
+
                     return (
                         <TableRow
                             key={item[0]}
@@ -79,10 +86,10 @@ export default function TableCard({
                                         onClick={() => onClick(key as string)}
                                         className="hover:underline select-text text-left"
                                     >
-                                        {label}
+                                        {formattedLabel}
                                     </button>
                                 ) : (
-                                    label
+                                    formattedLabel
                                 )}
                             </TableCell>
 

--- a/packages/server/app/components/TableCard.tsx
+++ b/packages/server/app/components/TableCard.tsx
@@ -64,8 +64,8 @@ export default function TableCard({
                     // the description can be either a single string (that is both the key and the label),
                     // or a tuple of type [key, label]
                     const [key, label] = Array.isArray(desc)
-                        ? [desc[0], desc[1] || "(none)"]
-                        : [desc, desc || "(none)"];
+                        ? [desc[0], desc[1] || "(unknown)"]
+                        : [desc, desc || "(unknown)"];
 
                     return (
                         <TableRow

--- a/packages/server/app/routes/__tests__/resources.device.test.tsx
+++ b/packages/server/app/routes/__tests__/resources.device.test.tsx
@@ -29,8 +29,8 @@ describe("Resources/Device route", () => {
             fetch.mockResolvedValueOnce(
                 createFetchResponse({
                     data: [
-                        { blob7: "Android", count: "5" },
-                        { blob7: "Windows", count: "1" },
+                        { blob10: "Desktop", count: "5" },
+                        { blob10: "Mobile", count: "1" },
                     ],
                 }),
             );
@@ -46,8 +46,8 @@ describe("Resources/Device route", () => {
             const json = await response;
             expect(json).toEqual({
                 countsByProperty: [
-                    ["Android", 5],
-                    ["Windows", 1],
+                    ["Desktop", 5],
+                    ["Mobile", 1],
                 ],
                 page: 1,
             });

--- a/packages/server/app/routes/resources.device.tsx
+++ b/packages/server/app/routes/resources.device.tsx
@@ -52,6 +52,9 @@ export const DeviceCard = ({
                 onFilterChange({ ...filters, deviceModel })
             }
             timezone={timezone}
+            labelFormatter={(label) =>
+                label.charAt(0).toUpperCase() + label.slice(1)
+            }
         />
     );
 };

--- a/packages/server/app/routes/resources.device.tsx
+++ b/packages/server/app/routes/resources.device.tsx
@@ -16,7 +16,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     const filters = getFiltersFromSearchParams(url.searchParams);
 
     return {
-        countsByProperty: await analyticsEngine.getCountByDevice(
+        countsByProperty: await analyticsEngine.getCountByDeviceType(
             site,
             interval,
             tz,


### PR DESCRIPTION
The idea thinking that it's more useful to understand device types (desktop, mobile, tablet, console) than to get an often-inaccurate breakdown of individual device types.

This makes the following changes:
* The `/collect` endpoint now extracts device type from the user agent and writes to `blob10`
* The Device card now queries from this column instead of `blob7` (`deviceModel`)
* `deviceModel` becomes pseudo-deprecated; it is still being written to the database, but it is no longer read back (to be revisited)

Once device type becomes populated, the device card should look like this:

![image](https://github.com/user-attachments/assets/32bc57b2-8ddb-4070-8eb1-17ad6bbc220e)

I've deployed this version to `counterscale.dev` to observe production data for a while first.

Refs #168