### PR TITLE
fix: Render version at the bottom of layout (again)

### DIFF
--- a/packages/cli/src/__tests__/cloudflare.test.ts
+++ b/packages/cli/src/__tests__/cloudflare.test.ts
@@ -183,7 +183,7 @@ describe("CloudflareClient", () => {
                 };
             });
 
-            const result = await client.deploy(false);
+            const result = await client.deploy(false, "0.0.1");
             expect(result).toBe("https://test-worker.test-account.workers.dev");
         });
 
@@ -194,7 +194,7 @@ describe("CloudflareClient", () => {
                 };
             });
 
-            const result = await client.deploy(false);
+            const result = await client.deploy(false, "0.0.1");
             expect(result).toBe("<unknown>");
         });
 
@@ -203,7 +203,7 @@ describe("CloudflareClient", () => {
                 throw new Error("Deployment failed");
             });
 
-            await expect(client.deploy(false)).rejects.toThrow(
+            await expect(client.deploy(false, "0.0.1")).rejects.toThrow(
                 "Deployment failed",
             );
         });

--- a/packages/cli/src/cloudflare.ts
+++ b/packages/cli/src/cloudflare.ts
@@ -77,11 +77,11 @@ export class CloudflareClient {
         return true;
     }
 
-    async deploy(verbose: boolean): Promise<string> {
+    async deploy(verbose: boolean, version: string): Promise<string> {
         try {
             const p = $({
                 quiet: true,
-            })`npx wrangler deploy --config ${this.configPath}`;
+            })`npx wrangler deploy --config ${this.configPath} --var VERSION:${version}`;
 
             let output = "";
             for await (const text of p) {

--- a/packages/cli/src/install.ts
+++ b/packages/cli/src/install.ts
@@ -264,7 +264,10 @@ Your token needs these permissions:
                 s.stop(`Deploying Counterscale ...`);
             }
 
-            deployUrl = await cloudflare.deploy(opts.verbose ? true : false);
+            deployUrl = await cloudflare.deploy(
+                opts.verbose ? true : false,
+                serverPkgJson.version,
+            );
 
             if (!opts.verbose) {
                 s.stop("Deploying Counterscale ... Done.");

--- a/packages/server/app/__tests__/root.test.tsx
+++ b/packages/server/app/__tests__/root.test.tsx
@@ -17,7 +17,10 @@ describe("Root", () => {
     test("renders without crashing", async () => {
         function loader() {
             return {
-                version: "ABC123",
+                version: {
+                    name: "ABC123",
+                    url: "http://example.com/commit/ABC123",
+                },
                 origin: "http://example.com",
                 url: "http://example.com/path",
             };

--- a/packages/server/app/root.tsx
+++ b/packages/server/app/root.tsx
@@ -57,8 +57,10 @@ export const loader = ({ context, request }: LoaderFunctionArgs) => {
 
 export const Layout = ({ children = [] }: { children: React.ReactNode }) => {
     const data = useLoaderData<typeof loader>() ?? {
-        version: "unknown",
-        versionUrl: null,
+        version: {
+            url: "https://example.com/",
+            name: "0.0.1",
+        },
         origin: "counterscale.dev",
         url: "https://counterscale.dev/",
     };

--- a/packages/server/app/root.tsx
+++ b/packages/server/app/root.tsx
@@ -46,7 +46,6 @@ export const loader = ({ context, request }: LoaderFunctionArgs) => {
     // specified during deploy via wrangler --var VERSION:value
     const version = context.cloudflare?.env?.VERSION;
 
-    console.log("here!", getVersionMeta(version));
     return {
         version: {
             ...getVersionMeta(version),

--- a/packages/server/app/root.tsx
+++ b/packages/server/app/root.tsx
@@ -13,11 +13,45 @@ import {
 
 export const links: LinksFunction = () => [{ rel: "stylesheet", href: styles }];
 
+/**
+ * Generate GitHub information based on the version format
+ * @param version - Version string (semver or git SHA)
+ * @returns Object with GitHub URL and display version
+ */
+function getVersionMeta(version: string | null | undefined): {
+    url: string | null;
+    name: string | null;
+} {
+    if (!version) return { url: null, name: null };
+
+    // Check if it's a semver (e.g., 1.2.3) or a git SHA
+    const isSemver = /^\d+\.\d+\.\d+(?:-[\w.-]+)?(?:\+[\w.-]+)?$/.test(version);
+
+    if (isSemver) {
+        // Link to release page for semver
+        return {
+            url: `https://github.com/benvinegar/counterscale/releases/tag/v${version}`,
+            name: version,
+        };
+    } else {
+        // Link to commit for git SHA - show only first 7 characters
+        return {
+            url: `https://github.com/benvinegar/counterscale/commit/${version}`,
+            name: version.slice(0, 7),
+        };
+    }
+}
+
 export const loader = ({ context, request }: LoaderFunctionArgs) => {
-    const url = new URL(request.url);
+    // specified during deploy via wrangler --var VERSION:value
+    const version = context.cloudflare?.env?.VERSION;
+
+    console.log("here!", getVersionMeta(version));
     return {
-        version: context.cloudflare?.env?.CF_PAGES_COMMIT_SHA,
-        origin: url.origin,
+        version: {
+            ...getVersionMeta(version),
+        },
+        origin: new URL(request.url).origin,
         url: request.url,
     };
 };
@@ -25,6 +59,7 @@ export const loader = ({ context, request }: LoaderFunctionArgs) => {
 export const Layout = ({ children = [] }: { children: React.ReactNode }) => {
     const data = useLoaderData<typeof loader>() ?? {
         version: "unknown",
+        versionUrl: null,
         origin: "counterscale.dev",
         url: "https://counterscale.dev/",
     };
@@ -130,11 +165,18 @@ export default function App() {
             <footer className="py-4 flex justify-end text-s">
                 <div>
                     Version{" "}
-                    <a
-                        href={`https://github.com/benvinegar/counterscale/commit/${data.version}`}
-                    >
-                        {data.version?.slice(0, 7)}
-                    </a>
+                    {data.version ? (
+                        <a
+                            href={data.version.url as string}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="hover:underline"
+                        >
+                            {data.version.name}
+                        </a>
+                    ) : (
+                        "unknown"
+                    )}
                 </div>
             </footer>
         </div>

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,8 +21,8 @@
     "scripts": {
         "dev": "react-router dev",
         "build": "react-router build",
-        "preview": "wrangler dev",
-        "deploy": "wrangler deploy",
+        "preview": "wrangler dev --var VERSION:`git rev-parse HEAD`",
+        "deploy": "wrangler deploy --var VERSION:`git rev-parse HEAD`",
         "lint": "eslint .",
         "test": "TZ=EST vitest run",
         "test-ci": "TZ=EST vitest run --coverage",


### PR DESCRIPTION
It's a little more sophisticated this time:

If deployed from a clone (i.e. during development), will use the HEAD git sha as "version". Clicking the link brings you to that commit on GitHub.

If deployed using the CLI (e.g. via `npx @counterscale/cli install`), will use the current release version as declared in package.json (e.g. v3.0.0). Clicking the link brings you to the release notes on GitHub for that release.

Fixes #174

- [ ] Before merging, need to verify version behavior from the CLI and from a new package.