### PR TITLE
fix: Device type filters

### DIFF
--- a/packages/server/app/analytics/query.ts
+++ b/packages/server/app/analytics/query.ts
@@ -133,7 +133,7 @@ function filtersToSql(filters: SearchFilters) {
         "browserName",
         "browserVersion",
         "country",
-        "deviceModel",
+        "deviceType",
     ];
 
     let filterStr = "";

--- a/packages/server/app/lib/__tests__/utils.test.ts
+++ b/packages/server/app/lib/__tests__/utils.test.ts
@@ -15,12 +15,12 @@ dayjs.extend(timezone);
 describe("getFiltersFromSearchParams", () => {
     test("it should return an object with the correct keys", () => {
         const searchParams = new URLSearchParams(
-            "?path=/about&referrer=google.com&deviceModel=iphone&country=us&browserName=chrome&browserVersion=118",
+            "?path=/about&referrer=google.com&deviceType=mobile&country=us&browserName=chrome&browserVersion=118",
         );
         expect(getFiltersFromSearchParams(searchParams)).toEqual({
             path: "/about",
             referrer: "google.com",
-            deviceModel: "iphone",
+            deviceType: "mobile",
             country: "us",
             browserName: "chrome",
             browserVersion: "118",

--- a/packages/server/app/lib/types.ts
+++ b/packages/server/app/lib/types.ts
@@ -2,6 +2,7 @@ export interface SearchFilters {
     path?: string;
     referrer?: string;
     deviceModel?: string;
+    deviceType?: string;
     country?: string;
     browserName?: string;
     browserVersion?: string;

--- a/packages/server/app/lib/utils.ts
+++ b/packages/server/app/lib/utils.ts
@@ -23,7 +23,7 @@ export function paramsFromUrl(url: string) {
 interface SearchFilters {
     path?: string;
     referrer?: string;
-    deviceModel?: string;
+    deviceType?: string;
     country?: string;
     browserName?: string;
     browserVersion?: string;
@@ -38,8 +38,8 @@ export function getFiltersFromSearchParams(searchParams: URLSearchParams) {
     if (searchParams.has("referrer")) {
         filters.referrer = searchParams.get("referrer") || "";
     }
-    if (searchParams.has("deviceModel")) {
-        filters.deviceModel = searchParams.get("deviceModel") || "";
+    if (searchParams.has("deviceType")) {
+        filters.deviceType = searchParams.get("deviceType") || "";
     }
     if (searchParams.has("country")) {
         filters.country = searchParams.get("country") || "";

--- a/packages/server/app/routes/resources.device.tsx
+++ b/packages/server/app/routes/resources.device.tsx
@@ -48,9 +48,7 @@ export const DeviceCard = ({
             dataFetcher={useFetcher<typeof loader>()}
             loaderUrl="/resources/device"
             filters={filters}
-            onClick={(deviceModel) =>
-                onFilterChange({ ...filters, deviceModel })
-            }
+            onClick={(deviceType) => onFilterChange({ ...filters, deviceType })}
             timezone={timezone}
             labelFormatter={(label) =>
                 label.charAt(0).toUpperCase() + label.slice(1)


### PR DESCRIPTION
Clicking a device type should filter all queries (charts, table cards) by that device type.

This regression was introduced in #175 when device _model_ became device _type_.

Refs #119 