### PR TITLE
Simplify cache API (refs #180)

### DIFF
--- a/packages/server/app/routes/__tests__/cache.test.tsx
+++ b/packages/server/app/routes/__tests__/cache.test.tsx
@@ -28,8 +28,7 @@ describe("Cache route", () => {
             // Verify the content of the response
             const data = await response.json();
             expect(data).toEqual({
-                v: 1, // New visitor with no If-Modified-Since
-                b: 1, // Also a bounce with no If-Modified-Since
+                ht: 1, // First hit (new visit) with no If-Modified-Since
             });
 
             // Verify headers
@@ -57,10 +56,10 @@ describe("Cache route", () => {
             // Verify the content of the response
             const data = await response.json();
 
-            // Should NOT be a new visitor
-            expect(data.v).toBe(0);
-            // Should NOT be a bounce
-            expect(data.b).toBe(0);
+            // Should return a hit count > 0 for returning visitors
+            expect(data.ht).toBeGreaterThan(0);
+            // The hit count should be the seconds value of the next date
+            // We don't test for a specific value since it's implementation-dependent
         });
 
         test("if-modified since is within 30 minutes but over day boundary", async () => {
@@ -84,10 +83,8 @@ describe("Cache route", () => {
             // Verify the content of the response
             const data = await response.json();
 
-            // Should be a new visitor because a new day began
-            expect(data.v).toBe(1);
-            // Should be a bounce
-            expect(data.b).toBe(1);
+            // Should be the first hit (new visitor) because a new day began
+            expect(data.ht).toBe(1);
         });
 
         test("if-modified-since is over 30 days ago", async () => {
@@ -109,10 +106,8 @@ describe("Cache route", () => {
             // Verify the content of the response
             const data = await response.json();
 
-            // Should be a new visitor because > 30 days passed
-            expect(data.v).toBe(1);
-            // Should be a bounce
-            expect(data.b).toBe(1);
+            // Should be the first hit (new visitor) because > 30 days passed
+            expect(data.ht).toBe(1);
         });
 
         test("if-modified-since was yesterday", async () => {
@@ -134,10 +129,8 @@ describe("Cache route", () => {
             // Verify the content of the response
             const data = await response.json();
 
-            // Should be a new visitor because > 24 hours passed
-            expect(data.v).toBe(1);
-            // Should be a bounce
-            expect(data.b).toBe(1);
+            // Should be the first hit (new visitor) because > 24 hours passed
+            expect(data.ht).toBe(1);
         });
 
         test("if-modified-since is one second after midnight", async () => {
@@ -165,10 +158,10 @@ describe("Cache route", () => {
             // Verify the content of the response
             const data = await response.json();
 
-            // Should NOT be a new visitor
-            expect(data.v).toBe(0);
-            // Should be a non-bounce (or negative bounce in the original tests)
-            expect(data.b).toBe(-1);
+            // Should return a hit count > 0 for returning visitors
+            expect(data.ht).toBe(2);
+            // The hit count should be the seconds value of the next date
+            // We don't test for a specific value since it's implementation-dependent
         });
 
         test("if-modified-since is two seconds after midnight", async () => {
@@ -198,10 +191,8 @@ describe("Cache route", () => {
             // Verify the content of the response
             const data = await response.json();
 
-            // Should NOT be a new visitor
-            expect(data.v).toBe(0);
-            // Should NOT be a bounce
-            expect(data.b).toBe(0);
+            // Should be the third hit (returning visitor)
+            expect(data.ht).toBe(3);
         });
     });
 });

--- a/packages/server/app/routes/__tests__/cache.test.tsx
+++ b/packages/server/app/routes/__tests__/cache.test.tsx
@@ -28,7 +28,7 @@ describe("Cache route", () => {
             // Verify the content of the response
             const data = await response.json();
             expect(data).toEqual({
-                ht: 1, // First hit (new visit) with no If-Modified-Since
+                hits: 1, // First hit (new visit) with no If-Modified-Since
             });
 
             // Verify headers
@@ -57,7 +57,7 @@ describe("Cache route", () => {
             const data = await response.json();
 
             // Should return a hit count > 0 for returning visitors
-            expect(data.ht).toBeGreaterThan(0);
+            expect(data.hits).toBeGreaterThan(0);
             // The hit count should be the seconds value of the next date
             // We don't test for a specific value since it's implementation-dependent
         });
@@ -84,7 +84,7 @@ describe("Cache route", () => {
             const data = await response.json();
 
             // Should be the first hit (new visitor) because a new day began
-            expect(data.ht).toBe(1);
+            expect(data.hits).toBe(1);
         });
 
         test("if-modified-since is over 30 days ago", async () => {
@@ -107,7 +107,7 @@ describe("Cache route", () => {
             const data = await response.json();
 
             // Should be the first hit (new visitor) because > 30 days passed
-            expect(data.ht).toBe(1);
+            expect(data.hits).toBe(1);
         });
 
         test("if-modified-since was yesterday", async () => {
@@ -130,7 +130,7 @@ describe("Cache route", () => {
             const data = await response.json();
 
             // Should be the first hit (new visitor) because > 24 hours passed
-            expect(data.ht).toBe(1);
+            expect(data.hits).toBe(1);
         });
 
         test("if-modified-since is one second after midnight", async () => {
@@ -159,7 +159,7 @@ describe("Cache route", () => {
             const data = await response.json();
 
             // Should return a hit count > 0 for returning visitors
-            expect(data.ht).toBe(2);
+            expect(data.hits).toBe(2);
             // The hit count should be the seconds value of the next date
             // We don't test for a specific value since it's implementation-dependent
         });
@@ -192,7 +192,7 @@ describe("Cache route", () => {
             const data = await response.json();
 
             // Should be the third hit (returning visitor)
-            expect(data.ht).toBe(3);
+            expect(data.hits).toBe(3);
         });
     });
 });

--- a/packages/server/app/routes/__tests__/collect.test.tsx
+++ b/packages/server/app/routes/__tests__/collect.test.tsx
@@ -22,14 +22,14 @@ describe("collect endpoint", () => {
         process.env.TZ = originalTZ;
     });
 
-    test("accepts v and b parameters and doesn't return caching headers", async () => {
-        // Create a request with v and b parameters
-        const requestWithVB = new Request(
-            "https://example.com/collect?sid=test-site&p=/test&h=example.com&r=&v=1&b=1",
+    test("accepts hits parameter and doesn't return Last-Modified header", async () => {
+        // Create a request with hits parameter
+        const requestWithHits = new Request(
+            "https://example.com/collect?sid=test-site&p=/test&h=example.com&r=&hits=1",
             { headers: new Headers() },
         );
 
-        const response = await collectRequestHandler(requestWithVB, mockEnv);
+        const response = await collectRequestHandler(requestWithHits, mockEnv);
 
         // Verify standard headers
         expect(response.status).toBe(200);
@@ -37,30 +37,30 @@ describe("collect endpoint", () => {
         expect(response.headers.get("Cache-Control")).toBe("no-cache");
         expect(response.headers.get("Pragma")).toBe("no-cache");
 
-        // The key assertion: Last-Modified header should NOT be present when v and b are provided
+        // The key assertion: Last-Modified header should NOT be present when hits is provided
         expect(response.headers.get("Last-Modified")).toBeNull();
     });
 
-    test("handles invalid v and b parameters", async () => {
-        // Create a request with invalid v and b parameters
-        const requestWithInvalidVB = new Request(
-            "https://example.com/collect?sid=test-site&p=/test&h=example.com&r=&v=invalid&b=invalid",
+    test("handles invalid hits parameter", async () => {
+        // Create a request with invalid hits parameter
+        const requestWithInvalidHits = new Request(
+            "https://example.com/collect?sid=test-site&p=/test&h=example.com&r=&hits=invalid",
             { headers: new Headers() },
         );
 
         const response = await collectRequestHandler(
-            requestWithInvalidVB,
+            requestWithInvalidHits,
             mockEnv,
         );
 
         expect(response.status).toBe(200);
 
-        // Even with invalid v and b, we should still not set Last-Modified
-        // because we're using the v/b path, not the cache headers path
+        // Even with invalid hits, we should NOT set Last-Modified
+        // because we're still using the hits parameter path
         expect(response.headers.get("Last-Modified")).toBeNull();
     });
 
-    test("falls back to cache headers when v and b are not provided", async () => {
+    test("falls back to cache headers when hits is not provided", async () => {
         // Use a fixed date for testing
         const initialDate = new Date("2025-04-01T12:00:00Z");
         const initialDateString = initialDate.toUTCString();

--- a/packages/server/app/routes/cache.tsx
+++ b/packages/server/app/routes/cache.tsx
@@ -12,12 +12,11 @@ import { handleCacheHeaders } from "~/analytics/collect";
 export async function loader({ request }: LoaderFunctionArgs) {
     const ifModifiedSince = request.headers.get("if-modified-since");
 
-    const { ht: hitCount, nextLastModifiedDate } =
-        handleCacheHeaders(ifModifiedSince);
+    const { hits, nextLastModifiedDate } = handleCacheHeaders(ifModifiedSince);
 
     // Return the hit count to the client
     const payload = {
-        ht: hitCount, // Number of hits in the current session (hit type)
+        hits, // Number of hits in the current session
     };
 
     // Return the JSON payload with the appropriate Last-Modified header

--- a/packages/server/app/routes/cache.tsx
+++ b/packages/server/app/routes/cache.tsx
@@ -4,21 +4,20 @@ import { handleCacheHeaders } from "~/analytics/collect";
 /**
  * Loader function for the /cache route.
  *
- * This route evaluates the If-Modified-Since header to determine if the request
- * corresponds to a new visit or a bounce, based on the cookieless tracking logic.
+ * This route evaluates the If-Modified-Since header to determine the number of hits
+ * within the current session, based on the cookieless tracking logic.
  * It returns this information as JSON and sets the Last-Modified header for the
  * next request.
  */
 export async function loader({ request }: LoaderFunctionArgs) {
     const ifModifiedSince = request.headers.get("if-modified-since");
 
-    const { isVisit, bounce, nextLastModifiedDate } =
+    const { ht: hitCount, nextLastModifiedDate } =
         handleCacheHeaders(ifModifiedSince);
 
-    // Use shorter parameter names for HTTP transmission
+    // Return the hit count to the client
     const payload = {
-        v: isVisit, // 1 or 0
-        b: bounce, // -1, 0, or 1
+        ht: hitCount, // Number of hits in the current session (hit type)
     };
 
     // Return the JSON payload with the appropriate Last-Modified header

--- a/packages/tracker/src/__tests__/index.spec.ts
+++ b/packages/tracker/src/__tests__/index.spec.ts
@@ -36,8 +36,7 @@ describe("api", () => {
         // Mock the checkCacheStatus function to return a default response
         vi.spyOn(requestModule, "checkCacheStatus").mockImplementation(() => {
             return Promise.resolve({
-                v: 1, // New visit
-                b: 1, // Bounce
+                ht: 1, // First hit (new visit)
             });
         });
     });
@@ -79,8 +78,7 @@ describe("api", () => {
             expect(searchParams.get("h")).toBe("http://localhost");
             expect(searchParams.get("p")).toBe("/"); // default path when running test w/ jsdom
             expect(searchParams.get("r")).toBe("");
-            expect(searchParams.get("v")).toBe("1"); // New visit
-            expect(searchParams.get("b")).toBe("1"); // Bounce
+            expect(searchParams.get("ht")).toBe("1"); // First hit (new visit)
         });
 
         test("records a pageview for the given url and referrer", async () => {
@@ -109,8 +107,7 @@ describe("api", () => {
             expect(searchParams.get("h")).toBe("https://example.com");
             expect(searchParams.get("p")).toBe("/foo");
             expect(searchParams.get("r")).toBe("https://referrer.com/");
-            expect(searchParams.get("v")).toBe("1"); // New visit
-            expect(searchParams.get("b")).toBe("1"); // Bounce
+            expect(searchParams.get("ht")).toBe("1"); // First hit (new visit)
         });
     });
 

--- a/packages/tracker/src/__tests__/index.spec.ts
+++ b/packages/tracker/src/__tests__/index.spec.ts
@@ -32,11 +32,11 @@ describe("api", () => {
         });
 
         vi.stubGlobal("XMLHttpRequest", XMLHttpRequestMock);
-        
+
         // Mock the checkCacheStatus function to return a default response
         vi.spyOn(requestModule, "checkCacheStatus").mockImplementation(() => {
             return Promise.resolve({
-                ht: 1, // First hit (new visit)
+                hits: 1, // First hit (new visit)
             });
         });
     });
@@ -78,7 +78,7 @@ describe("api", () => {
             expect(searchParams.get("h")).toBe("http://localhost");
             expect(searchParams.get("p")).toBe("/"); // default path when running test w/ jsdom
             expect(searchParams.get("r")).toBe("");
-            expect(searchParams.get("ht")).toBe("1"); // First hit (new visit)
+            expect(searchParams.get("hits")).toBe("1"); // First hit (new visit)
         });
 
         test("records a pageview for the given url and referrer", async () => {
@@ -107,7 +107,7 @@ describe("api", () => {
             expect(searchParams.get("h")).toBe("https://example.com");
             expect(searchParams.get("p")).toBe("/foo");
             expect(searchParams.get("r")).toBe("https://referrer.com/");
-            expect(searchParams.get("ht")).toBe("1"); // First hit (new visit)
+            expect(searchParams.get("hits")).toBe("1"); // First hit (new visit)
         });
     });
 
@@ -119,30 +119,30 @@ describe("api", () => {
                 reporterUrl: "https://example.com/collect",
                 autoTrackPageviews: true,
             });
-            
+
             // Wait for setTimeout in the Client constructor to execute
-            await new Promise(resolve => setTimeout(resolve, 50));
-            
+            await new Promise((resolve) => setTimeout(resolve, 50));
+
             // Check that at least one XHR request was made (initial pageview)
             expect(mockXhrObjects.length).toBeGreaterThan(0);
-            
+
             // Trigger a navigation event
             window.dispatchEvent(new Event("popstate"));
-            
+
             // Wait for the navigation event to be processed
-            await new Promise(resolve => setTimeout(resolve, 50));
-            
+            await new Promise((resolve) => setTimeout(resolve, 50));
+
             // Check that another XHR request was made (after navigation)
             const initialCount = mockXhrObjects.length;
             expect(initialCount).toBeGreaterThan(1);
-            
+
             // Trigger another navigation event
             window.history.pushState({}, "", "/another-page");
             window.dispatchEvent(new Event("popstate"));
-            
+
             // Wait for the second navigation event to be processed
-            await new Promise(resolve => setTimeout(resolve, 50));
-            
+            await new Promise((resolve) => setTimeout(resolve, 50));
+
             // Check that a third XHR request was made
             expect(mockXhrObjects.length).toBeGreaterThan(initialCount);
         });

--- a/packages/tracker/src/lib/__tests__/track.spec.ts
+++ b/packages/tracker/src/lib/__tests__/track.spec.ts
@@ -12,11 +12,11 @@ describe("trackPageview", () => {
         vi.spyOn(requestModule, "makeRequest").mockImplementation(
             makeRequestMock,
         );
-        
+
         // Mock the checkCacheStatus function to return a default response
         vi.spyOn(requestModule, "checkCacheStatus").mockImplementation(() => {
             return Promise.resolve({
-                ht: 1, // First hit (new visit)
+                hits: 1, // First hit (new visit)
             });
         });
 
@@ -70,7 +70,7 @@ describe("trackPageview", () => {
                 h: "http://localhost",
                 r: "",
                 sid: "test-site",
-                ht: "1", // First hit (new visit)
+                hits: "1", // First hit (new visit)
             }),
         );
     });

--- a/packages/tracker/src/lib/__tests__/track.spec.ts
+++ b/packages/tracker/src/lib/__tests__/track.spec.ts
@@ -16,8 +16,7 @@ describe("trackPageview", () => {
         // Mock the checkCacheStatus function to return a default response
         vi.spyOn(requestModule, "checkCacheStatus").mockImplementation(() => {
             return Promise.resolve({
-                v: 1, // New visit
-                b: 1, // Bounce
+                ht: 1, // First hit (new visit)
             });
         });
 
@@ -71,8 +70,7 @@ describe("trackPageview", () => {
                 h: "http://localhost",
                 r: "",
                 sid: "test-site",
-                v: "1", // New visit
-                b: "1", // Bounce
+                ht: "1", // First hit (new visit)
             }),
         );
     });

--- a/packages/tracker/src/lib/request.ts
+++ b/packages/tracker/src/lib/request.ts
@@ -10,8 +10,7 @@ type CollectRequestParams = {
 const REQUEST_TIMEOUT = 1000;
 
 type CacheResponse = {
-    v: number; // 1 for new visit, 0 for returning visitor
-    b: number; // 1 for bounce, 0 for normal, -1 for anti-bounce
+    ht: number; // Number of hits in the current session (hit type)
 };
 
 function queryParamStringify(obj: { [key: string]: string }) {
@@ -31,12 +30,14 @@ function queryParamStringify(obj: { [key: string]: string }) {
  * @param siteId The site ID to include in the cache URL
  * @returns A promise that resolves to the cache status
  */
-export function checkCacheStatus(baseUrl: string, siteId: string): Promise<CacheResponse> {
+export function checkCacheStatus(
+    baseUrl: string,
+    siteId: string,
+): Promise<CacheResponse> {
     return new Promise((resolve) => {
         // Default fallback response for any error case
         const fallbackResponse: CacheResponse = {
-            v: 1, // Assume new visit
-            b: 1, // Assume bounce
+            ht: 1, // Assume first hit (new visit)
         };
 
         // Replace the final /collect path segment with /cache and add site ID as a query parameter
@@ -46,7 +47,8 @@ export function checkCacheStatus(baseUrl: string, siteId: string): Promise<Cache
 
         xhr.open("GET", cacheUrl, true);
         xhr.timeout = REQUEST_TIMEOUT;
-        xhr.setRequestHeader("Content-Type", "application/json");
+        // needs to be text/plain or triggers preflight
+        xhr.setRequestHeader("Content-Type", "text/plain");
 
         xhr.onload = function () {
             if (xhr.status === 200) {

--- a/packages/tracker/src/lib/request.ts
+++ b/packages/tracker/src/lib/request.ts
@@ -3,8 +3,7 @@ type CollectRequestParams = {
     h: string; // host
     r: string; // referrer
     sid: string; // siteId
-    v?: string; // whether this is a new visit (1 or 0)
-    b?: string; // whether this is a bounce (1 or 0)
+    hits?: string; // hit count (1=first visit, 2=anti-bounce, 3=regular)
 };
 
 const REQUEST_TIMEOUT = 1000;

--- a/packages/tracker/src/lib/request.ts
+++ b/packages/tracker/src/lib/request.ts
@@ -10,7 +10,7 @@ type CollectRequestParams = {
 const REQUEST_TIMEOUT = 1000;
 
 type CacheResponse = {
-    ht: number; // Number of hits in the current session (hit type)
+    hits: number; // Number of hits in the current session
 };
 
 function queryParamStringify(obj: { [key: string]: string }) {
@@ -37,7 +37,7 @@ export function checkCacheStatus(
     return new Promise((resolve) => {
         // Default fallback response for any error case
         const fallbackResponse: CacheResponse = {
-            ht: 1, // Assume first hit (new visit)
+            hits: 1, // Assume first hit (new visit)
         };
 
         // Replace the final /collect path segment with /cache and add site ID as a query parameter

--- a/packages/tracker/src/lib/track.ts
+++ b/packages/tracker/src/lib/track.ts
@@ -77,11 +77,10 @@ export async function trackPageview(
         const cacheStatus = await checkCacheStatus(client.reporterUrl, client.siteId);
 
         Object.assign(d, {
-            v: cacheStatus.v.toString(),
-            b: cacheStatus.b.toString(),
+            ht: cacheStatus.ht.toString(),
         });
     } catch {
-        // If cache check fails, we proceed without visit/bounce data
+        // If cache check fails, we proceed without hit count data
         // The collect endpoint will handle the missing parameters
     }
 

--- a/packages/tracker/src/lib/track.ts
+++ b/packages/tracker/src/lib/track.ts
@@ -74,10 +74,13 @@ export async function trackPageview(
     };
 
     try {
-        const cacheStatus = await checkCacheStatus(client.reporterUrl, client.siteId);
+        const cacheStatus = await checkCacheStatus(
+            client.reporterUrl,
+            client.siteId,
+        );
 
         Object.assign(d, {
-            ht: cacheStatus.ht.toString(),
+            hits: cacheStatus.hits.toString(),
         });
     } catch {
         // If cache check fails, we proceed without hit count data


### PR DESCRIPTION
Remove the `b` (bounce value) and `v` (visit) parameters in favor of a single parameter, `ht` (hit type).

Hit type represents 3 possible states:
1. this is a new visitor (records the event as a new visitor and assumes the user bounced)
2. this is the _first_ repeat visit (not a new visitor, negates the earlier bounce by using a bounce value of `-1`)
3. this is any subsequent repeat visit (not a new visitor, not a bounce)

I think this has the benefit of avoiding exposing internal values, and simplifies the API surface area (just a single parameter, `ht`, with only 3 possible values).

Additionally snuck in a fix to the tracker to avoid CORS preflight requests (was setting wrong Content-Type)