### PR TITLE
fix: Admin redirect

### DIFF
--- a/packages/server/app/routes/admin-redirect.tsx
+++ b/packages/server/app/routes/admin-redirect.tsx
@@ -2,6 +2,6 @@ import { LoaderFunctionArgs, redirect } from "react-router";
 
 export const loader = async ({ context }: LoaderFunctionArgs) => {
     return redirect(
-        `https://dash.cloudflare.com/${context.cloudflare.env.CF_ACCOUNT_ID}/pages/view/counterscale`,
+        `https://dash.cloudflare.com/${context.cloudflare.env.CF_ACCOUNT_ID}/workers/services/view/counterscale`,
     );
 };


### PR DESCRIPTION
fix: update admin redirect URL to correct Cloudflare path


The root URL for CF Workers and Pages now is /workers-and-pages but since counterscale is a worker, this is the new URL in their dashboard