### PR TITLE
Improve init and add related functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ Counterscale.init({
 });
 ```
 
+__Available Methods__
+| Method | Parameters | Return Type | Description |
+|--------|------------|-------------|-------------|
+| `init(opts)` | `ClientOpts` | `void` | Initializes the Counterscale client with site configuration. Creates a global client instance if one doesn't exist. |
+| `isInitialized()` | None | `boolean` | Checks if the Counterscale client has been initialized. Returns true if client exists, false otherwise. |
+| `getInitializedClient()` | None | `Client \| undefined` | Returns the initialized client instance or undefined if not initialized. |
+| `trackPageview(opts?)` | `TrackPageviewOpts?` | `void` | Tracks a pageview event. Requires client to be initialized first. Automatically detects URL and referrer if not provided. |
+| `cleanup()` | None | `void` | Cleans up the client instance and removes event listeners. Sets global client to undefined. |
+
+
 ## Upgrading
 
 For most releases, upgrading is as simple as re-running the CLI installer:

--- a/packages/tracker/src/__tests__/index.spec.ts
+++ b/packages/tracker/src/__tests__/index.spec.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeAll, afterEach, vi } from "vitest";
 
 import * as Counterscale from "../index";
 import * as requestModule from "../lib/request";
+import { Client } from "~/lib/client";
 
 // Define a type for our mock XHR objects
 interface MockXHR {
@@ -46,11 +47,57 @@ describe("api", () => {
         Counterscale.cleanup();
     });
 
-    test("initializes", () => {
-        Counterscale.init({
-            siteId: "test-id",
-            reporterUrl: "https://example.com/collect",
-            autoTrackPageviews: false,
+    describe("init", () => {
+        test("initializes", () => {
+            Counterscale.init({
+                siteId: "test-id",
+                reporterUrl: "https://example.com/collect",
+                autoTrackPageviews: false,
+            });
+        });
+        test("does not error when init is called twice", () => {
+            expect(() => {
+                Counterscale.init({
+                    siteId: "test-id",
+                    reporterUrl: "https://example.com/collect",
+                    autoTrackPageviews: false,
+                });
+                Counterscale.init({
+                    siteId: "test-id",
+                    reporterUrl: "https://example.com/collect",
+                    autoTrackPageviews: false,
+                });
+            }).not.toThrow()
+        });
+    });
+
+    describe("isInitialized", () => {
+        test("returns true when init has been called", () => {
+            Counterscale.init({
+                siteId: "test-id",
+                reporterUrl: "https://example.com/collect",
+                autoTrackPageviews: false,
+            });
+            expect(Counterscale.isInitialized()).toBe(true);
+        });
+        test("returns false when init has not been called", () => {
+            expect(Counterscale.isInitialized()).toBe(false);
+        });
+    });
+
+    describe("getInitializedClient", () => {
+        test("returns an instance of a client if called after init", () => {
+            Counterscale.init({
+                siteId: "test-id",
+                reporterUrl: "https://example.com/collect",
+                autoTrackPageviews: false,
+            });
+
+            expect(Counterscale.getInitializedClient()).toBeInstanceOf(Client);
+        });
+
+        test("returns undefined if called without init", () => {
+            expect(Counterscale.getInitializedClient()).toBeUndefined();
         });
     });
 

--- a/packages/tracker/src/index.ts
+++ b/packages/tracker/src/index.ts
@@ -10,9 +10,17 @@ const GLOBALS = {
 
 export function init(opts: ClientOpts) {
     if (GLOBALS.client) {
-        throw new Error("Counterscale has already been initialized.");
+        return;
     }
     GLOBALS.client = new Client(opts);
+}
+
+export function isInitialized() {
+    return Boolean(GLOBALS.client);
+}
+
+export function getInitializedClient(): typeof GLOBALS["client"] {
+    return GLOBALS.client 
 }
 
 export function trackPageview(opts?: TrackPageviewOpts) {


### PR DESCRIPTION
Fixes #188
- Return silently from `Counterscale.init()` instead of throwing when a client is already initialized
- Adds `Counterscale.isInitialized()` - a convenience method if you need to know if a client exists but don't need the client itself
- Adds `Counterscale.getInitializedClient()` - returns a client if one exists, otherwise returns undefined
- Also adds docs for all `Counterscale.*` methods in the root README