### PR TITLE
tracker: add localhost tracking configuration

### DIFF
--- a/packages/tracker/integration/01_legacyInit/index.html
+++ b/packages/tracker/integration/01_legacyInit/index.html
@@ -16,6 +16,7 @@
         </script>
         <script
             id="counterscale-script"
+            data-report-localhost
             src="http://localhost:3004/tracker.js"
         ></script>
     </body>

--- a/packages/tracker/integration/02_dataAttrsInit/index.html
+++ b/packages/tracker/integration/02_dataAttrsInit/index.html
@@ -7,6 +7,7 @@
         <script
             id="counterscale-script"
             data-site-id="your-unique-site-id"
+            data-report-localhost
             src="http://localhost:3004/tracker.js"
         ></script>
     </body>

--- a/packages/tracker/integration/03_pushState/index.html
+++ b/packages/tracker/integration/03_pushState/index.html
@@ -6,6 +6,7 @@
         <script
             id="counterscale-script"
             data-site-id="your-unique-site-id"
+            data-report-localhost
             src="http://localhost:3004/tracker.js"
         ></script>
     </head>

--- a/packages/tracker/src/__tests__/index.spec.ts
+++ b/packages/tracker/src/__tests__/index.spec.ts
@@ -105,6 +105,7 @@ describe("api", () => {
         test("records a pageview for the current url", async () => {
             Counterscale.init({
                 siteId: "test-id",
+                reportOnLocalhost: true,
                 reporterUrl: "https://example.com/collect",
                 autoTrackPageviews: false,
             });
@@ -131,6 +132,7 @@ describe("api", () => {
         test("records a pageview for the given url and referrer", async () => {
             Counterscale.init({
                 siteId: "test-id",
+                reportOnLocalhost: true,
                 reporterUrl: "https://example.com/collect",
                 autoTrackPageviews: false,
             });
@@ -163,6 +165,7 @@ describe("api", () => {
             // Initialize with autoTrackPageviews: true
             Counterscale.init({
                 siteId: "test-id",
+                reportOnLocalhost: true,
                 reporterUrl: "https://example.com/collect",
                 autoTrackPageviews: true,
             });
@@ -192,6 +195,45 @@ describe("api", () => {
 
             // Check that a third XHR request was made
             expect(mockXhrObjects.length).toBeGreaterThan(initialCount);
+        });
+    });
+
+    describe("reportOnLocalhost", () => {
+        test("should not report on localhost by default", async () => {
+            Counterscale.init({
+                siteId: "test-id",
+                reporterUrl: "https://example.com/collect",
+                autoTrackPageviews: false,
+            });
+
+            // since auto: false, no requests should be made yet
+            expect(mockXhrObjects).toHaveLength(0);
+
+            await Counterscale.trackPageview({
+                url: "https://example.com/foo",
+                referrer: "https://referrer.com/",
+            });
+
+            expect(mockXhrObjects).toHaveLength(0);
+        });
+
+        test("should report on localhost when reportOnLocalhost is set to true", async () => {
+            Counterscale.init({
+                siteId: "test-id",
+                reportOnLocalhost: true,
+                reporterUrl: "https://example.com/collect",
+                autoTrackPageviews: false,
+            });
+
+            // since auto: false, no requests should be made yet
+            expect(mockXhrObjects).toHaveLength(0);
+
+            await Counterscale.trackPageview({
+                url: "https://example.com/foo",
+                referrer: "https://referrer.com/",
+            });
+
+            expect(mockXhrObjects).toHaveLength(1);
         });
     });
 });

--- a/packages/tracker/src/lib/client.ts
+++ b/packages/tracker/src/lib/client.ts
@@ -2,6 +2,7 @@ import { autoTrackPageviews } from "./track";
 
 export type ClientOpts = {
     siteId: string;
+    reportOnLocalhost?: boolean;
     reporterUrl: string;
     autoTrackPageviews?: boolean;
 };
@@ -9,12 +10,17 @@ export type ClientOpts = {
 export class Client {
     siteId: string;
     reporterUrl: string;
+    reportOnLocalhost = false;
 
     _cleanupAutoTrackPageviews?: () => void;
 
     constructor(opts: ClientOpts) {
         this.siteId = opts.siteId;
         this.reporterUrl = opts.reporterUrl;
+
+        if (opts.reportOnLocalhost) {
+          this.reportOnLocalhost = opts.reportOnLocalhost;
+        }
 
         // default to true
         if (opts.autoTrackPageviews === undefined || opts.autoTrackPageviews) {

--- a/packages/tracker/src/lib/track.ts
+++ b/packages/tracker/src/lib/track.ts
@@ -48,12 +48,20 @@ function getReferrer(hostname: string, referrer: string) {
     return referrer.split("?")[0];
 }
 
+function isLocalhostAddress(hostname: Location["hostname"]): boolean {
+  return /^localhost$|^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*:)*?:?0*1$/.test(hostname)
+}
+
 export async function trackPageview(
     client: Client,
     opts: TrackPageviewOpts = {},
 ) {
     const canonical = getCanonicalUrl();
     const location = canonical ?? window.location;
+
+    if (!client.reportOnLocalhost && isLocalhostAddress(window.location.hostname)) {
+      return;
+    }
 
     // if host is empty, we're probably loading a file:/// URI
     // -- exit early if this is not an Electron app

--- a/packages/tracker/src/tracker.ts
+++ b/packages/tracker/src/tracker.ts
@@ -31,6 +31,7 @@ function getLegacySiteId(): string | undefined {
 function init() {
     const script = findReporterScript();
     const siteId = script?.getAttribute("data-site-id") || getLegacySiteId();
+    const reportOnLocalhost = script?.hasAttribute("data-report-localhost") || true;
 
     const reporterUrl = script?.src.replace("tracker.js", "collect");
 
@@ -40,6 +41,7 @@ function init() {
 
     Counterscale.init({
         siteId,
+        reportOnLocalhost,
         reporterUrl,
         autoTrackPageviews: true,
     });

--- a/packages/tracker/src/tracker.ts
+++ b/packages/tracker/src/tracker.ts
@@ -31,7 +31,7 @@ function getLegacySiteId(): string | undefined {
 function init() {
     const script = findReporterScript();
     const siteId = script?.getAttribute("data-site-id") || getLegacySiteId();
-    const reportOnLocalhost = script?.hasAttribute("data-report-localhost") || true;
+    const reportOnLocalhost = (script?.hasAttribute("data-report-localhost") && script?.getAttribute("data-report-localhost") !== "false") || false;
 
     const reporterUrl = script?.src.replace("tracker.js", "collect");
 


### PR DESCRIPTION
# Overview
Closes #50 
- adds a new boolean option to `Counterscale.init` named `reportOnLocalhost` (defaults to `false`) that enables/disables collecting events when the page is localhost, or any local IP address
- for those using the tracker script, add a `data-report-localhost` to the tracker's script tag to enable tracking on localhost
  - If using a templating engine like JSX, you can use booleans to conditionally enable reporting on localhost via the tracker script (ie `data-report-localhost={isDev ? true : false }`
  
