### PR TITLE
fix: rm duplicate external link icon

### DIFF
--- a/packages/server/app/components/TableCard.tsx
+++ b/packages/server/app/components/TableCard.tsx
@@ -131,15 +131,6 @@ export default function TableCard({
                                         ) : (
                                             formattedLabel
                                         )}
-                                        <a
-                                            href={label}
-                                            target={"_blank"}
-                                            rel="noreferrer"
-                                            aria-hidden="true"
-                                            className="inline whitespace-nowrap ml-1"
-                                        >
-                                            <ExternalLink size={16} />
-                                        </a>
                                     </>
                                 )}
                             </TableCell>


### PR DESCRIPTION
In #216 I introduced a regression where `ExternalLink` icons were rendered for all labels, not just those that match the previous regex