### PR TITLE
Fix: Wrap Long URLs in TableCard Component

### DIFF
--- a/packages/server/app/components/TableCard.tsx
+++ b/packages/server/app/components/TableCard.tsx
@@ -100,7 +100,7 @@ export default function TableCard({
                                                 onClick={() =>
                                                     onClick(key as string)
                                                 }
-                                                className="hover:underline select-text text-left"
+                                                className="hover:underline select-text text-left break-all"
                                             >
                                                 {formattedLabel}
                                             </button>


### PR DESCRIPTION
**Description**: This PR updates the TableCard component to properly wrap long URLs, preventing layout overflow and improving readability. Previously, long URLs could break the table layout or extend beyond the visible area. With this change, URLs will wrap within their container, ensuring a cleaner and more user-friendly display.

**Changes**:

Added CSS styles to enable word wrapping for long URLs in the table.
Verified that table layout remains consistent with various URL lengths.
No impact on other components or functionality.
Motivation: Improves UI/UX by handling edge cases where URLs are excessively long, ensuring the table remains usable and visually appealing.

**Testing**:

Manually tested with short and long URLs.
Confirmed that wrapping works on Chrome and Firefox.

**Before Changes**
<img width="1481" height="456" alt="2025-09-13_14-23" src="https://github.com/user-attachments/assets/0b380125-b6b0-4b1b-ba20-743d466c92d1" />

**After Changes**
<img width="1447" height="448" alt="2025-09-13_14-26" src="https://github.com/user-attachments/assets/c6c17aac-7e55-42ee-96fc-f22a08e7cec0" />
