### PR TITLE
UTM Tracking

### DIFF
--- a/packages/server/app/analytics/__tests__/query.test.ts
+++ b/packages/server/app/analytics/__tests__/query.test.ts
@@ -483,6 +483,143 @@ describe("AnalyticsEngineAPI", () => {
             });
         });
     });
+
+    describe("UTM query methods", () => {
+        test("getCountByUtmSource should return visitor counts by UTM source", async () => {
+            fetch.mockResolvedValue(
+                createFetchResponse({
+                    data: [
+                        {
+                            blob11: "google",
+                            count: 50,
+                        },
+                        {
+                            blob11: "facebook",
+                            count: 30,
+                        },
+                        {
+                            blob11: "twitter",
+                            count: 20,
+                        },
+                    ],
+                }),
+            );
+
+            const result = await api.getCountByUtmSource("example.com", "7d");
+
+            expect(fetch).toHaveBeenCalled();
+            expect(result).toEqual([
+                ["google", 50],
+                ["facebook", 30],
+                ["twitter", 20],
+            ]);
+        });
+
+        test("getCountByUtmMedium should return visitor counts by UTM medium", async () => {
+            fetch.mockResolvedValue(
+                createFetchResponse({
+                    data: [
+                        {
+                            blob12: "cpc",
+                            count: 40,
+                        },
+                        {
+                            blob12: "email",
+                            count: 35,
+                        },
+                        {
+                            blob12: "social",
+                            count: 25,
+                        },
+                    ],
+                }),
+            );
+
+            const result = await api.getCountByUtmMedium("example.com", "7d");
+
+            expect(fetch).toHaveBeenCalled();
+            expect(result).toEqual([
+                ["cpc", 40],
+                ["email", 35],
+                ["social", 25],
+            ]);
+        });
+
+        test("getCountByUtmCampaign should return visitor counts by UTM campaign", async () => {
+            fetch.mockResolvedValue(
+                createFetchResponse({
+                    data: [
+                        {
+                            blob13: "summer_sale",
+                            count: 60,
+                        },
+                        {
+                            blob13: "newsletter",
+                            count: 40,
+                        },
+                    ],
+                }),
+            );
+
+            const result = await api.getCountByUtmCampaign("example.com", "7d");
+
+            expect(fetch).toHaveBeenCalled();
+            expect(result).toEqual([
+                ["summer_sale", 60],
+                ["newsletter", 40],
+            ]);
+        });
+
+        test("getCountByUtmTerm should return visitor counts by UTM term", async () => {
+            fetch.mockResolvedValue(
+                createFetchResponse({
+                    data: [
+                        {
+                            blob14: "analytics",
+                            count: 15,
+                        },
+                        {
+                            blob14: "web tracking",
+                            count: 10,
+                        },
+                    ],
+                }),
+            );
+
+            const result = await api.getCountByUtmTerm("example.com", "7d");
+
+            expect(fetch).toHaveBeenCalled();
+            expect(result).toEqual([
+                ["analytics", 15],
+                ["web tracking", 10],
+            ]);
+        });
+
+        test("getCountByUtmContent should return visitor counts by UTM content", async () => {
+            fetch.mockResolvedValue(
+                createFetchResponse({
+                    data: [
+                        {
+                            blob15: "banner_ad",
+                            count: 25,
+                        },
+                        {
+                            blob15: "text_link",
+                            count: 15,
+                        },
+                    ],
+                }),
+            );
+
+            const result = await api.getCountByUtmContent("example.com", "7d");
+
+            expect(fetch).toHaveBeenCalled();
+            expect(result).toEqual([
+                ["banner_ad", 25],
+                ["text_link", 15],
+            ]);
+        });
+    });
 });
 
 describe("intervalToSql", () => {

--- a/packages/server/app/analytics/collect.ts
+++ b/packages/server/app/analytics/collect.ts
@@ -193,6 +193,12 @@ export function collectRequestHandler(
         browserVersion: browserVersion,
         deviceModel: parsedUserAgent.getDevice().model,
         deviceType: getDeviceTypeFromDevice(parsedUserAgent.getDevice()),
+        // UTM parameters
+        utmSource: params.us,
+        utmMedium: params.um,
+        utmCampaign: params.uc,
+        utmTerm: params.ut,
+        utmContent: params.uco,
     };
 
     // NOTE: location is derived from Cloudflare-specific request properties
@@ -247,6 +253,11 @@ interface DataPoint {
     browserVersion?: string;
     deviceModel?: string;
     deviceType?: string;
+    utmSource?: string;
+    utmMedium?: string;
+    utmCampaign?: string;
+    utmTerm?: string;
+    utmContent?: string;
 
     // doubles
     newVisitor: number;
@@ -274,6 +285,11 @@ export function writeDataPoint(
             data.siteId || "", // blob8
             data.browserVersion || "", // blob9
             data.deviceType || "", // blob10
+            data.utmSource || "", // blob11
+            data.utmMedium || "", // blob12
+            data.utmCampaign || "", // blob13
+            data.utmTerm || "", // blob14
+            data.utmContent || "", // blob15
         ],
         doubles: [data.newVisitor || 0, data.newSession || 0, data.bounce],
     };

--- a/packages/server/app/analytics/query.ts
+++ b/packages/server/app/analytics/query.ts
@@ -135,6 +135,11 @@ function filtersToSql(filters: SearchFilters) {
         "browserVersion",
         "country",
         "deviceType",
+        "utmSource",
+        "utmMedium",
+        "utmCampaign",
+        "utmTerm",
+        "utmContent",
     ];
 
     let filterStr = "";
@@ -700,6 +705,91 @@ export class AnalyticsEngineAPI {
         return this.getVisitorCountByColumn(
             siteId,
             "deviceType",
+            interval,
+            tz,
+            filters,
+            page,
+        );
+    }
+
+    async getCountByUtmSource(
+        siteId: string,
+        interval: string,
+        tz?: string,
+        filters: SearchFilters = {},
+        page: number = 1,
+    ): Promise<[utmSource: string, visitors: number][]> {
+        return this.getVisitorCountByColumn(
+            siteId,
+            "utmSource",
+            interval,
+            tz,
+            filters,
+            page,
+        );
+    }
+
+    async getCountByUtmMedium(
+        siteId: string,
+        interval: string,
+        tz?: string,
+        filters: SearchFilters = {},
+        page: number = 1,
+    ): Promise<[utmMedium: string, visitors: number][]> {
+        return this.getVisitorCountByColumn(
+            siteId,
+            "utmMedium",
+            interval,
+            tz,
+            filters,
+            page,
+        );
+    }
+
+    async getCountByUtmCampaign(
+        siteId: string,
+        interval: string,
+        tz?: string,
+        filters: SearchFilters = {},
+        page: number = 1,
+    ): Promise<[utmCampaign: string, visitors: number][]> {
+        return this.getVisitorCountByColumn(
+            siteId,
+            "utmCampaign",
+            interval,
+            tz,
+            filters,
+            page,
+        );
+    }
+
+    async getCountByUtmTerm(
+        siteId: string,
+        interval: string,
+        tz?: string,
+        filters: SearchFilters = {},
+        page: number = 1,
+    ): Promise<[utmTerm: string, visitors: number][]> {
+        return this.getVisitorCountByColumn(
+            siteId,
+            "utmTerm",
+            interval,
+            tz,
+            filters,
+            page,
+        );
+    }
+
+    async getCountByUtmContent(
+        siteId: string,
+        interval: string,
+        tz?: string,
+        filters: SearchFilters = {},
+        page: number = 1,
+    ): Promise<[utmContent: string, visitors: number][]> {
+        return this.getVisitorCountByColumn(
+            siteId,
+            "utmContent",
             interval,
             tz,
             filters,

--- a/packages/server/app/analytics/schema.ts
+++ b/packages/server/app/analytics/schema.ts
@@ -24,6 +24,11 @@ export const ColumnMappings = {
     siteId: "blob8",
     browserVersion: "blob9",
     deviceType: "blob10",
+    utmSource: "blob11",
+    utmMedium: "blob12",
+    utmCampaign: "blob13",
+    utmTerm: "blob14",
+    utmContent: "blob15",
 
     /**
      * doubles

--- a/packages/server/app/lib/__tests__/utils.test.ts
+++ b/packages/server/app/lib/__tests__/utils.test.ts
@@ -34,6 +34,33 @@ describe("getFiltersFromSearchParams", () => {
             path: "/about",
         });
     });
+
+    test("it should handle UTM parameters correctly", () => {
+        const searchParams = new URLSearchParams(
+            "?utmSource=google&utmMedium=cpc&utmCampaign=summer_sale&utmTerm=analytics&utmContent=banner_ad&path=/landing",
+        );
+        expect(getFiltersFromSearchParams(searchParams)).toEqual({
+            utmSource: "google",
+            utmMedium: "cpc",
+            utmCampaign: "summer_sale",
+            utmTerm: "analytics",
+            utmContent: "banner_ad",
+            path: "/landing",
+        });
+    });
+
+    test("it should handle mixed standard and UTM parameters", () => {
+        const searchParams = new URLSearchParams(
+            "?path=/about&referrer=google.com&utmSource=google&utmMedium=email&browserName=chrome",
+        );
+        expect(getFiltersFromSearchParams(searchParams)).toEqual({
+            path: "/about",
+            referrer: "google.com",
+            utmSource: "google",
+            utmMedium: "email",
+            browserName: "chrome",
+        });
+    });
 });
 
 describe("getDateTimeRange", () => {

--- a/packages/server/app/lib/types.ts
+++ b/packages/server/app/lib/types.ts
@@ -6,6 +6,11 @@ export interface SearchFilters {
     country?: string;
     browserName?: string;
     browserVersion?: string;
+    utmSource?: string;
+    utmMedium?: string;
+    utmCampaign?: string;
+    utmTerm?: string;
+    utmContent?: string;
 }
 
 export interface User {

--- a/packages/server/app/lib/utils.ts
+++ b/packages/server/app/lib/utils.ts
@@ -27,6 +27,11 @@ interface SearchFilters {
     country?: string;
     browserName?: string;
     browserVersion?: string;
+    utmSource?: string;
+    utmMedium?: string;
+    utmCampaign?: string;
+    utmTerm?: string;
+    utmContent?: string;
 }
 
 export function getFiltersFromSearchParams(searchParams: URLSearchParams) {
@@ -49,6 +54,21 @@ export function getFiltersFromSearchParams(searchParams: URLSearchParams) {
     }
     if (searchParams.has("browserVersion")) {
         filters.browserVersion = searchParams.get("browserVersion") || "";
+    }
+    if (searchParams.has("utmSource")) {
+        filters.utmSource = searchParams.get("utmSource") || "";
+    }
+    if (searchParams.has("utmMedium")) {
+        filters.utmMedium = searchParams.get("utmMedium") || "";
+    }
+    if (searchParams.has("utmCampaign")) {
+        filters.utmCampaign = searchParams.get("utmCampaign") || "";
+    }
+    if (searchParams.has("utmTerm")) {
+        filters.utmTerm = searchParams.get("utmTerm") || "";
+    }
+    if (searchParams.has("utmContent")) {
+        filters.utmContent = searchParams.get("utmContent") || "";
     }
 
     return filters;

--- a/packages/server/app/routes/__tests__/dashboard.test.tsx
+++ b/packages/server/app/routes/__tests__/dashboard.test.tsx
@@ -272,6 +272,36 @@ describe("Dashboard route", () => {
                             return { countsByProperty: [] };
                         },
                     },
+                    {
+                        path: "/resources/utm-source",
+                        loader: () => {
+                            return { countsByProperty: [] };
+                        },
+                    },
+                    {
+                        path: "/resources/utm-medium",
+                        loader: () => {
+                            return { countsByProperty: [] };
+                        },
+                    },
+                    {
+                        path: "/resources/utm-campaign",
+                        loader: () => {
+                            return { countsByProperty: [] };
+                        },
+                    },
+                    {
+                        path: "/resources/utm-term",
+                        loader: () => {
+                            return { countsByProperty: [] };
+                        },
+                    },
+                    {
+                        path: "/resources/utm-content",
+                        loader: () => {
+                            return { countsByProperty: [] };
+                        },
+                    },
                 ],
             },
         ]);
@@ -284,6 +314,11 @@ describe("Dashboard route", () => {
         expect(screen.getByText("Browser")).toBeInTheDocument();
         expect(screen.getByText("Country")).toBeInTheDocument();
         expect(screen.getByText("Device")).toBeInTheDocument();
+        expect(screen.getByText("UTM Source")).toBeInTheDocument();
+        expect(screen.getByText("UTM Medium")).toBeInTheDocument();
+        expect(screen.getByText("UTM Campaign")).toBeInTheDocument();
+        expect(screen.getByText("UTM Term")).toBeInTheDocument();
+        expect(screen.getByText("UTM Content")).toBeInTheDocument();
     });
 
     const defaultMockedLoaderJson = {
@@ -309,7 +344,9 @@ describe("Dashboard route", () => {
 
     test("renders with valid data", async () => {
         function loader() {
-            return { ...defaultMockedLoaderJson };
+            return {
+                ...defaultMockedLoaderJson,
+            };
         }
 
         const RemixStub = createRoutesStub([
@@ -395,6 +432,36 @@ describe("Dashboard route", () => {
                     },
                     {
                         path: "/resources/browserversion",
+                        loader: () => {
+                            return { countsByProperty: [] };
+                        },
+                    },
+                    {
+                        path: "/resources/utm-source",
+                        loader: () => {
+                            return { countsByProperty: [] };
+                        },
+                    },
+                    {
+                        path: "/resources/utm-medium",
+                        loader: () => {
+                            return { countsByProperty: [] };
+                        },
+                    },
+                    {
+                        path: "/resources/utm-campaign",
+                        loader: () => {
+                            return { countsByProperty: [] };
+                        },
+                    },
+                    {
+                        path: "/resources/utm-term",
+                        loader: () => {
+                            return { countsByProperty: [] };
+                        },
+                    },
+                    {
+                        path: "/resources/utm-content",
                         loader: () => {
                             return { countsByProperty: [] };
                         },

--- a/packages/server/app/routes/__tests__/resources.utm-campaign.test.tsx
+++ b/packages/server/app/routes/__tests__/resources.utm-campaign.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import {
+    vi,
+    test,
+    describe,
+    beforeEach,
+    afterEach,
+    expect,
+    Mock,
+} from "vitest";
+import "vitest-dom/extend-expect";
+
+import { loader } from "../resources.utm-campaign";
+import { createFetchResponse, getDefaultContext } from "./testutils";
+
+describe("Resources/UTM Campaign route", () => {
+    let fetch: Mock;
+
+    beforeEach(() => {
+        fetch = global.fetch = vi.fn();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe("loader", () => {
+        test("returns valid json with UTM campaign data", async () => {
+            fetch.mockResolvedValueOnce(
+                createFetchResponse({
+                    data: [
+                        { blob13: "summer_sale", count: "60" },
+                        { blob13: "newsletter", count: "40" },
+                        { blob13: "blog_post", count: "25" },
+                    ],
+                }),
+            );
+
+            const response = await loader({
+                ...getDefaultContext(),
+                // @ts-expect-error we don't need to provide all the properties of the request object
+                request: {
+                    url: "http://localhost:3000/resources/utm-campaign?site=example.com&interval=7d",
+                },
+            });
+
+            const json = await response;
+            expect(json).toEqual({
+                countsByProperty: [
+                    ["summer_sale", 60],
+                    ["newsletter", 40],
+                    ["blog_post", 25],
+                ],
+                page: 1,
+            });
+        });
+    });
+});

--- a/packages/server/app/routes/__tests__/resources.utm-content.test.tsx
+++ b/packages/server/app/routes/__tests__/resources.utm-content.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import {
+    vi,
+    test,
+    describe,
+    beforeEach,
+    afterEach,
+    expect,
+    Mock,
+} from "vitest";
+import "vitest-dom/extend-expect";
+
+import { loader } from "../resources.utm-content";
+import { createFetchResponse, getDefaultContext } from "./testutils";
+
+describe("Resources/UTM Content route", () => {
+    let fetch: Mock;
+
+    beforeEach(() => {
+        fetch = global.fetch = vi.fn();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe("loader", () => {
+        test("returns valid json with UTM content data", async () => {
+            fetch.mockResolvedValueOnce(
+                createFetchResponse({
+                    data: [
+                        { blob15: "banner_ad", count: "45" },
+                        { blob15: "sidebar_widget", count: "30" },
+                        { blob15: "footer_link", count: "20" },
+                    ],
+                }),
+            );
+
+            const response = await loader({
+                ...getDefaultContext(),
+                // @ts-expect-error we don't need to provide all the properties of the request object
+                request: {
+                    url: "http://localhost:3000/resources/utm-content?site=example.com&interval=7d",
+                },
+            });
+
+            const json = await response;
+            expect(json).toEqual({
+                countsByProperty: [
+                    ["banner_ad", 45],
+                    ["sidebar_widget", 30],
+                    ["footer_link", 20],
+                ],
+                page: 1,
+            });
+        });
+    });
+});

--- a/packages/server/app/routes/__tests__/resources.utm-medium.test.tsx
+++ b/packages/server/app/routes/__tests__/resources.utm-medium.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import {
+    vi,
+    test,
+    describe,
+    beforeEach,
+    afterEach,
+    expect,
+    Mock,
+} from "vitest";
+import "vitest-dom/extend-expect";
+
+import { loader } from "../resources.utm-medium";
+import { createFetchResponse, getDefaultContext } from "./testutils";
+
+describe("Resources/UTM Medium route", () => {
+    let fetch: Mock;
+
+    beforeEach(() => {
+        fetch = global.fetch = vi.fn();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe("loader", () => {
+        test("returns valid json with UTM medium data", async () => {
+            fetch.mockResolvedValueOnce(
+                createFetchResponse({
+                    data: [
+                        { blob12: "cpc", count: "40" },
+                        { blob12: "email", count: "35" },
+                        { blob12: "social", count: "25" },
+                    ],
+                }),
+            );
+
+            const response = await loader({
+                ...getDefaultContext(),
+                // @ts-expect-error we don't need to provide all the properties of the request object
+                request: {
+                    url: "http://localhost:3000/resources/utm-medium?site=example.com&interval=7d",
+                },
+            });
+
+            const json = await response;
+            expect(json).toEqual({
+                countsByProperty: [
+                    ["cpc", 40],
+                    ["email", 35],
+                    ["social", 25],
+                ],
+                page: 1,
+            });
+        });
+    });
+});

--- a/packages/server/app/routes/__tests__/resources.utm-source.test.tsx
+++ b/packages/server/app/routes/__tests__/resources.utm-source.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import {
+    vi,
+    test,
+    describe,
+    beforeEach,
+    afterEach,
+    expect,
+    Mock,
+} from "vitest";
+import "vitest-dom/extend-expect";
+
+import { loader } from "../resources.utm-source";
+import { createFetchResponse, getDefaultContext } from "./testutils";
+
+describe("Resources/UTM Source route", () => {
+    let fetch: Mock;
+
+    beforeEach(() => {
+        fetch = global.fetch = vi.fn();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe("loader", () => {
+        test("returns valid json with UTM source data", async () => {
+            fetch.mockResolvedValueOnce(
+                createFetchResponse({
+                    data: [
+                        { blob11: "google", count: "50" },
+                        { blob11: "facebook", count: "30" },
+                        { blob11: "twitter", count: "20" },
+                    ],
+                }),
+            );
+
+            const response = await loader({
+                ...getDefaultContext(),
+                // @ts-expect-error we don't need to provide all the properties of the request object
+                request: {
+                    url: "http://localhost:3000/resources/utm-source?site=example.com&interval=7d",
+                },
+            });
+
+            const json = await response;
+            expect(json).toEqual({
+                countsByProperty: [
+                    ["google", 50],
+                    ["facebook", 30],
+                    ["twitter", 20],
+                ],
+                page: 1,
+            });
+        });
+
+        test("handles empty UTM source data", async () => {
+            fetch.mockResolvedValueOnce(
+                createFetchResponse({
+                    data: [],
+                }),
+            );
+
+            const response = await loader({
+                ...getDefaultContext(),
+                // @ts-expect-error we don't need to provide all the properties of the request object
+                request: {
+                    url: "http://localhost:3000/resources/utm-source?site=example.com&interval=7d",
+                },
+            });
+
+            const json = await response;
+            expect(json).toEqual({
+                countsByProperty: [],
+                page: 1,
+            });
+        });
+    });
+});

--- a/packages/server/app/routes/__tests__/resources.utm-term.test.tsx
+++ b/packages/server/app/routes/__tests__/resources.utm-term.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import {
+    vi,
+    test,
+    describe,
+    beforeEach,
+    afterEach,
+    expect,
+    Mock,
+} from "vitest";
+import "vitest-dom/extend-expect";
+
+import { loader } from "../resources.utm-term";
+import { createFetchResponse, getDefaultContext } from "./testutils";
+
+describe("Resources/UTM Term route", () => {
+    let fetch: Mock;
+
+    beforeEach(() => {
+        fetch = global.fetch = vi.fn();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe("loader", () => {
+        test("returns valid json with UTM term data", async () => {
+            fetch.mockResolvedValueOnce(
+                createFetchResponse({
+                    data: [
+                        { blob14: "running_shoes", count: "55" },
+                        { blob14: "fitness_equipment", count: "35" },
+                        { blob14: "workout_clothes", count: "25" },
+                    ],
+                }),
+            );
+
+            const response = await loader({
+                ...getDefaultContext(),
+                // @ts-expect-error we don't need to provide all the properties of the request object
+                request: {
+                    url: "http://localhost:3000/resources/utm-term?site=example.com&interval=7d",
+                },
+            });
+
+            const json = await response;
+            expect(json).toEqual({
+                countsByProperty: [
+                    ["running_shoes", 55],
+                    ["fitness_equipment", 35],
+                    ["workout_clothes", 25],
+                ],
+                page: 1,
+            });
+        });
+    });
+});

--- a/packages/server/app/routes/dashboard.tsx
+++ b/packages/server/app/routes/dashboard.tsx
@@ -22,6 +22,11 @@ import { BrowserCard } from "./resources.browser";
 import { BrowserVersionCard } from "./resources.browserversion";
 import { CountryCard } from "./resources.country";
 import { DeviceCard } from "./resources.device";
+import { UtmSourceCard } from "./resources.utm-source";
+import { UtmMediumCard } from "./resources.utm-medium";
+import { UtmCampaignCard } from "./resources.utm-campaign";
+import { UtmTermCard } from "./resources.utm-term";
+import { UtmContentCard } from "./resources.utm-content";
 
 import {
     getFiltersFromSearchParams,
@@ -45,7 +50,7 @@ const MAX_RETENTION_DAYS = 90;
 
 export const loader = async ({ context, request }: LoaderFunctionArgs) => {
     await requireAuth(request, context.cloudflare.env);
-    
+
     // NOTE: probably duped from getLoadContext / need to de-duplicate
     if (!context.cloudflare?.env?.CF_ACCOUNT_ID) {
         throw new Response("Missing credentials: CF_ACCOUNT_ID is not set.", {
@@ -281,6 +286,48 @@ export default function Dashboard() {
                     />
 
                     <DeviceCard
+                        siteId={data.siteId}
+                        interval={data.interval}
+                        filters={data.filters}
+                        onFilterChange={handleFilterChange}
+                        timezone={userTimezone}
+                    />
+                </div>
+                <div className="grid md:grid-cols-3 gap-4 mb-4">
+                    <UtmSourceCard
+                        siteId={data.siteId}
+                        interval={data.interval}
+                        filters={data.filters}
+                        onFilterChange={handleFilterChange}
+                        timezone={userTimezone}
+                    />
+
+                    <UtmMediumCard
+                        siteId={data.siteId}
+                        interval={data.interval}
+                        filters={data.filters}
+                        onFilterChange={handleFilterChange}
+                        timezone={userTimezone}
+                    />
+
+                    <UtmCampaignCard
+                        siteId={data.siteId}
+                        interval={data.interval}
+                        filters={data.filters}
+                        onFilterChange={handleFilterChange}
+                        timezone={userTimezone}
+                    />
+                </div>
+                <div className="grid md:grid-cols-2 gap-4 mb-4">
+                    <UtmTermCard
+                        siteId={data.siteId}
+                        interval={data.interval}
+                        filters={data.filters}
+                        onFilterChange={handleFilterChange}
+                        timezone={userTimezone}
+                    />
+
+                    <UtmContentCard
                         siteId={data.siteId}
                         interval={data.interval}
                         filters={data.filters}

--- a/packages/server/app/routes/resources.utm-campaign.tsx
+++ b/packages/server/app/routes/resources.utm-campaign.tsx
@@ -1,0 +1,56 @@
+import { useFetcher } from "react-router";
+
+import type { LoaderFunctionArgs } from "react-router";
+
+import { getFiltersFromSearchParams, paramsFromUrl } from "~/lib/utils";
+import PaginatedTableCard from "~/components/PaginatedTableCard";
+import { SearchFilters } from "~/lib/types";
+
+export async function loader({ context, request }: LoaderFunctionArgs) {
+    const { analyticsEngine } = context;
+
+    const { interval, site, page = 1 } = paramsFromUrl(request.url);
+    const url = new URL(request.url);
+    const tz = url.searchParams.get("timezone") || "UTC";
+    const filters = getFiltersFromSearchParams(url.searchParams);
+
+    return {
+        countsByProperty: await analyticsEngine.getCountByUtmCampaign(
+            site,
+            interval,
+            tz,
+            filters,
+            Number(page),
+        ),
+        page: Number(page),
+    };
+}
+
+export const UtmCampaignCard = ({
+    siteId,
+    interval,
+    filters,
+    onFilterChange,
+    timezone,
+}: {
+    siteId: string;
+    interval: string;
+    filters: SearchFilters;
+    onFilterChange: (filters: SearchFilters) => void;
+    timezone: string;
+}) => {
+    return (
+        <PaginatedTableCard
+            siteId={siteId}
+            interval={interval}
+            columnHeaders={["UTM Campaign", "Visitors"]}
+            dataFetcher={useFetcher<typeof loader>()}
+            loaderUrl="/resources/utm-campaign"
+            filters={filters}
+            onClick={(utmCampaign) =>
+                onFilterChange({ ...filters, utmCampaign })
+            }
+            timezone={timezone}
+        />
+    );
+};

--- a/packages/server/app/routes/resources.utm-content.tsx
+++ b/packages/server/app/routes/resources.utm-content.tsx
@@ -1,0 +1,54 @@
+import { useFetcher } from "react-router";
+
+import type { LoaderFunctionArgs } from "react-router";
+
+import { getFiltersFromSearchParams, paramsFromUrl } from "~/lib/utils";
+import PaginatedTableCard from "~/components/PaginatedTableCard";
+import { SearchFilters } from "~/lib/types";
+
+export async function loader({ context, request }: LoaderFunctionArgs) {
+    const { analyticsEngine } = context;
+
+    const { interval, site, page = 1 } = paramsFromUrl(request.url);
+    const url = new URL(request.url);
+    const tz = url.searchParams.get("timezone") || "UTC";
+    const filters = getFiltersFromSearchParams(url.searchParams);
+
+    return {
+        countsByProperty: await analyticsEngine.getCountByUtmContent(
+            site,
+            interval,
+            tz,
+            filters,
+            Number(page),
+        ),
+        page: Number(page),
+    };
+}
+
+export const UtmContentCard = ({
+    siteId,
+    interval,
+    filters,
+    onFilterChange,
+    timezone,
+}: {
+    siteId: string;
+    interval: string;
+    filters: SearchFilters;
+    onFilterChange: (filters: SearchFilters) => void;
+    timezone: string;
+}) => {
+    return (
+        <PaginatedTableCard
+            siteId={siteId}
+            interval={interval}
+            columnHeaders={["UTM Content", "Visitors"]}
+            dataFetcher={useFetcher<typeof loader>()}
+            loaderUrl="/resources/utm-content"
+            filters={filters}
+            onClick={(utmContent) => onFilterChange({ ...filters, utmContent })}
+            timezone={timezone}
+        />
+    );
+};

--- a/packages/server/app/routes/resources.utm-medium.tsx
+++ b/packages/server/app/routes/resources.utm-medium.tsx
@@ -1,0 +1,54 @@
+import { useFetcher } from "react-router";
+
+import type { LoaderFunctionArgs } from "react-router";
+
+import { getFiltersFromSearchParams, paramsFromUrl } from "~/lib/utils";
+import PaginatedTableCard from "~/components/PaginatedTableCard";
+import { SearchFilters } from "~/lib/types";
+
+export async function loader({ context, request }: LoaderFunctionArgs) {
+    const { analyticsEngine } = context;
+
+    const { interval, site, page = 1 } = paramsFromUrl(request.url);
+    const url = new URL(request.url);
+    const tz = url.searchParams.get("timezone") || "UTC";
+    const filters = getFiltersFromSearchParams(url.searchParams);
+
+    return {
+        countsByProperty: await analyticsEngine.getCountByUtmMedium(
+            site,
+            interval,
+            tz,
+            filters,
+            Number(page),
+        ),
+        page: Number(page),
+    };
+}
+
+export const UtmMediumCard = ({
+    siteId,
+    interval,
+    filters,
+    onFilterChange,
+    timezone,
+}: {
+    siteId: string;
+    interval: string;
+    filters: SearchFilters;
+    onFilterChange: (filters: SearchFilters) => void;
+    timezone: string;
+}) => {
+    return (
+        <PaginatedTableCard
+            siteId={siteId}
+            interval={interval}
+            columnHeaders={["UTM Medium", "Visitors"]}
+            dataFetcher={useFetcher<typeof loader>()}
+            loaderUrl="/resources/utm-medium"
+            filters={filters}
+            onClick={(utmMedium) => onFilterChange({ ...filters, utmMedium })}
+            timezone={timezone}
+        />
+    );
+};

--- a/packages/server/app/routes/resources.utm-source.tsx
+++ b/packages/server/app/routes/resources.utm-source.tsx
@@ -1,0 +1,54 @@
+import { useFetcher } from "react-router";
+
+import type { LoaderFunctionArgs } from "react-router";
+
+import { getFiltersFromSearchParams, paramsFromUrl } from "~/lib/utils";
+import PaginatedTableCard from "~/components/PaginatedTableCard";
+import { SearchFilters } from "~/lib/types";
+
+export async function loader({ context, request }: LoaderFunctionArgs) {
+    const { analyticsEngine } = context;
+
+    const { interval, site, page = 1 } = paramsFromUrl(request.url);
+    const url = new URL(request.url);
+    const tz = url.searchParams.get("timezone") || "UTC";
+    const filters = getFiltersFromSearchParams(url.searchParams);
+
+    return {
+        countsByProperty: await analyticsEngine.getCountByUtmSource(
+            site,
+            interval,
+            tz,
+            filters,
+            Number(page),
+        ),
+        page: Number(page),
+    };
+}
+
+export const UtmSourceCard = ({
+    siteId,
+    interval,
+    filters,
+    onFilterChange,
+    timezone,
+}: {
+    siteId: string;
+    interval: string;
+    filters: SearchFilters;
+    onFilterChange: (filters: SearchFilters) => void;
+    timezone: string;
+}) => {
+    return (
+        <PaginatedTableCard
+            siteId={siteId}
+            interval={interval}
+            columnHeaders={["UTM Source", "Visitors"]}
+            dataFetcher={useFetcher<typeof loader>()}
+            loaderUrl="/resources/utm-source"
+            filters={filters}
+            onClick={(utmSource) => onFilterChange({ ...filters, utmSource })}
+            timezone={timezone}
+        />
+    );
+};

--- a/packages/server/app/routes/resources.utm-term.tsx
+++ b/packages/server/app/routes/resources.utm-term.tsx
@@ -1,0 +1,54 @@
+import { useFetcher } from "react-router";
+
+import type { LoaderFunctionArgs } from "react-router";
+
+import { getFiltersFromSearchParams, paramsFromUrl } from "~/lib/utils";
+import PaginatedTableCard from "~/components/PaginatedTableCard";
+import { SearchFilters } from "~/lib/types";
+
+export async function loader({ context, request }: LoaderFunctionArgs) {
+    const { analyticsEngine } = context;
+
+    const { interval, site, page = 1 } = paramsFromUrl(request.url);
+    const url = new URL(request.url);
+    const tz = url.searchParams.get("timezone") || "UTC";
+    const filters = getFiltersFromSearchParams(url.searchParams);
+
+    return {
+        countsByProperty: await analyticsEngine.getCountByUtmTerm(
+            site,
+            interval,
+            tz,
+            filters,
+            Number(page),
+        ),
+        page: Number(page),
+    };
+}
+
+export const UtmTermCard = ({
+    siteId,
+    interval,
+    filters,
+    onFilterChange,
+    timezone,
+}: {
+    siteId: string;
+    interval: string;
+    filters: SearchFilters;
+    onFilterChange: (filters: SearchFilters) => void;
+    timezone: string;
+}) => {
+    return (
+        <PaginatedTableCard
+            siteId={siteId}
+            interval={interval}
+            columnHeaders={["UTM Term", "Visitors"]}
+            dataFetcher={useFetcher<typeof loader>()}
+            loaderUrl="/resources/utm-term"
+            filters={filters}
+            onClick={(utmTerm) => onFilterChange({ ...filters, utmTerm })}
+            timezone={timezone}
+        />
+    );
+};

--- a/packages/tracker/integration/04_utmTracking/index.html
+++ b/packages/tracker/integration/04_utmTracking/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+    <head>
+        <title>04 UTM Tracking</title>
+    </head>
+    <body>
+        <h1>UTM Tracking Test</h1>
+        <p>This page tests UTM parameter tracking functionality.</p>
+
+        <script>
+            (function () {
+                window.counterscale = {
+                    q: [
+                        ["set", "siteId", "utm-test-site-id"],
+                        ["trackPageview"],
+                    ],
+                };
+            })();
+        </script>
+        <script
+            id="counterscale-script"
+            data-report-localhost
+            src="http://localhost:3004/tracker.js"
+        ></script>
+    </body>
+</html>

--- a/packages/tracker/integration/04_utmTracking/index.spec.ts
+++ b/packages/tracker/integration/04_utmTracking/index.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from "@playwright/test";
+
+test("tracks UTM parameters when present in URL", async ({ page }) => {
+    const collectRequestPromise = page.waitForRequest((request) =>
+        request.url().includes("/collect"),
+    );
+
+    await page.goto(
+        "http://localhost:3004/04_utmTracking/?utm_source=google&utm_medium=cpc&utm_campaign=summer_sale&utm_term=analytics&utm_content=banner",
+    );
+
+    // Wait for the request to /collect
+    const request = await collectRequestPromise;
+    expect(request).toBeTruthy();
+
+    const url = request.url();
+    expect(request.method()).toBe("GET");
+
+    const params = new URLSearchParams(url.split("?")[1]);
+
+    expect(params.get("sid")).toBe("utm-test-site-id");
+    expect(params.get("h")).toBe("http://localhost");
+    expect(params.get("p")).toBe("/04_utmTracking/");
+    expect(params.get("r")).toBe("");
+
+    expect(params.get("us")).toBe("google"); // utm_source
+    expect(params.get("um")).toBe("cpc"); // utm_medium
+    expect(params.get("uc")).toBe("summer_sale"); // utm_campaign
+    expect(params.get("ut")).toBe("analytics"); // utm_term
+    expect(params.get("uco")).toBe("banner"); // utm_content
+});
+
+test("tracks only non-empty UTM parameters", async ({ page }) => {
+    const collectRequestPromise = page.waitForRequest((request) =>
+        request.url().includes("/collect"),
+    );
+
+    // Navigate with partial UTM parameters (empty utm_medium)
+    await page.goto(
+        "http://localhost:3004/04_utmTracking/?utm_source=newsletter&utm_medium=&utm_campaign=launch",
+    );
+
+    const request = await collectRequestPromise;
+    expect(request).toBeTruthy();
+
+    const url = request.url();
+    const params = new URLSearchParams(url.split("?")[1]);
+
+    // Check that only non-empty UTM parameters are sent
+    expect(params.get("us")).toBe("newsletter"); // utm_source present
+    expect(params.get("uc")).toBe("launch"); // utm_campaign present
+    expect(params.has("um")).toBe(false); // utm_medium not sent (empty)
+    expect(params.has("ut")).toBe(false); // utm_term not sent (missing)
+    expect(params.has("uco")).toBe(false); // utm_content not sent (missing)
+});
+
+test("handles URL-encoded UTM parameters", async ({ page }) => {
+    const collectRequestPromise = page.waitForRequest((request) =>
+        request.url().includes("/collect"),
+    );
+
+    // Navigate with URL-encoded UTM parameters
+    await page.goto(
+        "http://localhost:3004/04_utmTracking/?utm_campaign=summer%20sale&utm_content=blue%20button",
+    );
+
+    const request = await collectRequestPromise;
+    expect(request).toBeTruthy();
+
+    const url = request.url();
+    const params = new URLSearchParams(url.split("?")[1]);
+
+    // Check URL-encoded parameters are properly decoded
+    expect(params.get("uc")).toBe("summer sale"); // utm_campaign decoded
+    expect(params.get("uco")).toBe("blue button"); // utm_content decoded
+});
+
+test("handles mixed UTM and non-UTM parameters", async ({ page }) => {
+    const collectRequestPromise = page.waitForRequest((request) =>
+        request.url().includes("/collect"),
+    );
+
+    // Navigate with mixed parameters
+    await page.goto(
+        "http://localhost:3004/04_utmTracking/?page=1&utm_source=twitter&sort=date&utm_campaign=launch&filter=active",
+    );
+
+    const request = await collectRequestPromise;
+    expect(request).toBeTruthy();
+
+    const url = request.url();
+    const params = new URLSearchParams(url.split("?")[1]);
+
+    // Check UTM parameters are extracted correctly
+    expect(params.get("us")).toBe("twitter");
+    expect(params.get("uc")).toBe("launch");
+
+    // Check non-UTM parameters are not sent as UTM
+    expect(params.has("um")).toBe(false);
+    expect(params.has("ut")).toBe(false);
+    expect(params.has("uco")).toBe(false);
+});

--- a/packages/tracker/integration/server.js
+++ b/packages/tracker/integration/server.js
@@ -35,9 +35,11 @@ http.createServer(function (req, res) {
         res.writeHead(404, { "Content-Type": "text/html" });
         res.end("Not found");
     } else {
-        const resolvedUrl = req.url.endsWith("/")
-            ? req.url + "index.html"
-            : req.url;
+        // Strip query parameters for file resolution
+        const urlWithoutQuery = requestUrl.pathname;
+        const resolvedUrl = urlWithoutQuery.endsWith("/")
+            ? urlWithoutQuery + "index.html"
+            : urlWithoutQuery;
         const filePath = path.join(__dirname, resolvedUrl);
         let file;
         try {

--- a/packages/tracker/src/lib/track.ts
+++ b/packages/tracker/src/lib/track.ts
@@ -48,8 +48,35 @@ function getReferrer(hostname: string, referrer: string) {
     return referrer.split("?")[0];
 }
 
+function getUtmParams(url: string) {
+    const utmParams: Record<string, string> = {};
+
+    // Extract query string from path
+    const queryStart = url.indexOf("?");
+    if (queryStart === -1) return utmParams;
+
+    const queryString = url.substring(queryStart + 1);
+    const params = new URLSearchParams(queryString);
+
+    const utmSource = params.get("utm_source");
+    const utmMedium = params.get("utm_medium");
+    const utmCampaign = params.get("utm_campaign");
+    const utmTerm = params.get("utm_term");
+    const utmContent = params.get("utm_content");
+
+    if (utmSource) utmParams.us = utmSource;
+    if (utmMedium) utmParams.um = utmMedium;
+    if (utmCampaign) utmParams.uc = utmCampaign;
+    if (utmTerm) utmParams.ut = utmTerm;
+    if (utmContent) utmParams.uco = utmContent;
+
+    return utmParams;
+}
+
 function isLocalhostAddress(hostname: Location["hostname"]): boolean {
-  return /^localhost$|^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*:)*?:?0*1$/.test(hostname)
+    return /^localhost$|^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*:)*?:?0*1$/.test(
+        hostname,
+    );
 }
 
 export async function trackPageview(
@@ -59,8 +86,11 @@ export async function trackPageview(
     const canonical = getCanonicalUrl();
     const location = canonical ?? window.location;
 
-    if (!client.reportOnLocalhost && isLocalhostAddress(window.location.hostname)) {
-      return;
+    if (
+        !client.reportOnLocalhost &&
+        isLocalhostAddress(window.location.hostname)
+    ) {
+        return;
     }
 
     // if host is empty, we're probably loading a file:/// URI
@@ -80,6 +110,9 @@ export async function trackPageview(
         r: referrer,
         sid: client.siteId,
     };
+
+    const utmParams = getUtmParams(url);
+    Object.assign(d, utmParams);
 
     try {
         const cacheStatus = await checkCacheStatus(


### PR DESCRIPTION
## Overview
Closes #138 by adding utm support to the server (/collect endpoint), tracker and dashboard. Implementation is based on [this doc from Plausible](https://plausible.io/blog/utm-tracking-tags#types-of-utm-parameters)

## Changes
### @counterscale/tracker
- Adds UTM parameter extraction from URLs

### @counterscale/server
- Adds support for UTM parameters in the /collect endpoint
- Adds UTM to schema (blob 11-15)
- Adds `getCountBy*` queries for all UTM parameters
- Adds loaders and components for querying and displaying UTM data (resources.utm-*.tsx)
- Integrates UTM cards into the dashboard
