### PR TITLE
feat: token validation on install

### DIFF
--- a/packages/cli/src/commands/__tests__/install.test.ts
+++ b/packages/cli/src/commands/__tests__/install.test.ts
@@ -1,7 +1,6 @@
 process.env.NODE_ENV = "test";
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import type { PasswordOptions } from "@clack/prompts";
 
 // Mock modules must be imported before the actual imports
 vi.mock("@clack/prompts", () => ({
@@ -28,6 +27,7 @@ vi.mock("../../lib/cloudflare.js", () => ({
         setCloudflareSecrets: vi.fn(),
         deploy: vi.fn(),
     })),
+    validateCloudflareToken: vi.fn(),
 }));
 
 // Now import the actual modules
@@ -61,7 +61,23 @@ describe("install prompts", () => {
     });
 
     describe("promptApiToken", () => {
-        it("should return valid API token", async () => {
+        let mockSpinner: {
+            start: ReturnType<typeof vi.fn>;
+            stop: ReturnType<typeof vi.fn>;
+        };
+
+        beforeEach(async () => {
+            mockSpinner = {
+                start: vi.fn(),
+                stop: vi.fn(),
+            };
+            const mockPrompts = await import("@clack/prompts");
+            (
+                mockPrompts.spinner as unknown as ReturnType<typeof vi.fn>
+            ).mockReturnValue(mockSpinner);
+        });
+
+        it("should return valid API token when validation passes", async () => {
             const mockToken = "a".repeat(40);
             (isCancel as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
                 false,
@@ -70,6 +86,13 @@ describe("install prompts", () => {
             (
                 mockPrompts.password as unknown as ReturnType<typeof vi.fn>
             ).mockResolvedValue(mockToken);
+
+            const mockCloudflare = await import("../../lib/cloudflare.js");
+            (
+                mockCloudflare.validateCloudflareToken as unknown as ReturnType<
+                    typeof vi.fn
+                >
+            ).mockResolvedValue({ valid: true });
 
             const result = await promptApiToken();
             expect(result).toBe(mockToken);
@@ -89,43 +112,71 @@ describe("install prompts", () => {
             );
         });
 
-        it("should throw error if token is not a string", async () => {
+        it("should throw error if token validation fails", async () => {
+            const mockToken = "a".repeat(40);
             (isCancel as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
                 false,
             );
             const mockPrompts = await import("@clack/prompts");
             (
                 mockPrompts.password as unknown as ReturnType<typeof vi.fn>
-            ).mockResolvedValue(undefined);
+            ).mockResolvedValue(mockToken);
+
+            const mockCloudflare = await import("../../lib/cloudflare.js");
+            (
+                mockCloudflare.validateCloudflareToken as unknown as ReturnType<
+                    typeof vi.fn
+                >
+            ).mockResolvedValue({
+                valid: false,
+                error: "Invalid token or insufficient permissions",
+            });
 
             await expect(promptApiToken()).rejects.toThrow(
-                "API token is required",
+                "Invalid token or insufficient permissions",
             );
         });
 
-        it("should validate token length", async () => {
-            // Call promptApiToken to get the actual validate function
+        it("should throw error if validation throws", async () => {
+            const mockToken = "a".repeat(40);
+            (isCancel as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+                false,
+            );
             const mockPrompts = await import("@clack/prompts");
             (
                 mockPrompts.password as unknown as ReturnType<typeof vi.fn>
-            ).mockImplementationOnce(({ validate }: PasswordOptions) => {
-                if (!validate) {
-                    throw new Error("validate function missing");
-                }
+            ).mockResolvedValue(mockToken);
 
-                expect(validate("")).toBe("Value is required");
-                expect(validate("a".repeat(39))).toBe(
-                    "Value must be exactly 40 characters",
-                );
-                expect(validate("a".repeat(41))).toBe(
-                    "Value must be exactly 40 characters",
-                );
-                expect(validate("a".repeat(40))).toBeUndefined();
-                return "mock-token";
-            });
+            const mockCloudflare = await import("../../lib/cloudflare.js");
+            (
+                mockCloudflare.validateCloudflareToken as unknown as ReturnType<
+                    typeof vi.fn
+                >
+            ).mockRejectedValue(new Error("Network error"));
 
-            await promptApiToken();
-            expect(mockPrompts.password).toHaveBeenCalled();
+            await expect(promptApiToken()).rejects.toThrow("Network error");
+        });
+
+        it("should throw generic error if validation throws non-Error", async () => {
+            const mockToken = "a".repeat(40);
+            (isCancel as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+                false,
+            );
+            const mockPrompts = await import("@clack/prompts");
+            (
+                mockPrompts.password as unknown as ReturnType<typeof vi.fn>
+            ).mockResolvedValue(mockToken);
+
+            const mockCloudflare = await import("../../lib/cloudflare.js");
+            (
+                mockCloudflare.validateCloudflareToken as unknown as ReturnType<
+                    typeof vi.fn
+                >
+            ).mockRejectedValue("string error");
+
+            await expect(promptApiToken()).rejects.toThrow(
+                "Failed to validate token. Please check your internet connection.",
+            );
         });
     });
 
@@ -372,6 +423,4 @@ describe("install prompts", () => {
             expect(shouldPrompt).toBe(true);
         });
     });
-
-
 });

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -75,7 +75,7 @@ export async function promptApiToken(): Promise<string> {
 
     try {
         const result = await validateCloudflareToken(cfApiToken);
-        s.stop();
+        s.stop("Token Validated");
 
         if (!result.valid) {
             throw new Error(

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -25,10 +25,7 @@ import {
     getWorkerAndDatasetName,
 } from "../lib/config.js";
 
-import {
-    CloudflareClient,
-    validateCloudflareToken,
-} from "../lib/cloudflare.js";
+import { CloudflareClient } from "../lib/cloudflare.js";
 import {
     getScriptSnippet,
     getPackageSnippet,
@@ -74,7 +71,7 @@ export async function promptApiToken(): Promise<string> {
     s.start("Validating token...");
 
     try {
-        const result = await validateCloudflareToken(cfApiToken);
+        const result = await CloudflareClient.validateToken(cfApiToken);
         s.stop("Token Validated");
 
         if (!result.valid) {

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -25,8 +25,16 @@ import {
     getWorkerAndDatasetName,
 } from "../lib/config.js";
 
-import { CloudflareClient } from "../lib/cloudflare.js";
-import { getScriptSnippet, getPackageSnippet, CLI_COLORS, promptForPassword } from "../lib/ui.js";
+import {
+    CloudflareClient,
+    validateCloudflareToken,
+} from "../lib/cloudflare.js";
+import {
+    getScriptSnippet,
+    getPackageSnippet,
+    CLI_COLORS,
+    promptForPassword,
+} from "../lib/ui.js";
 import { generateJWTSecret, generatePasswordHash } from "../lib/auth.js";
 
 export function bail() {
@@ -41,12 +49,16 @@ export async function promptApiToken(): Promise<string> {
     const cfApiToken = await password({
         message: "Enter your Cloudflare API Token",
         mask: "*",
-        validate: (val) => {
-            if (val.length === 0) {
-                return "Value is required";
-            } else if (val.length !== 40) {
-                return "Value must be exactly 40 characters";
+        validate: (value) => {
+            if (typeof value !== "string" || value.length === 0) {
+                return "API token is required";
             }
+
+            if (value.length < 40) {
+                return "Token appears to be too short";
+            }
+
+            return undefined;
         },
     });
 
@@ -54,14 +66,35 @@ export async function promptApiToken(): Promise<string> {
         bail();
     }
 
-    if (typeof cfApiToken !== "string") {
+    if (typeof cfApiToken !== "string" || cfApiToken.length === 0) {
         throw new Error("API token is required");
+    }
+
+    const s = spinner();
+    s.start("Validating token...");
+
+    try {
+        const result = await validateCloudflareToken(cfApiToken);
+        s.stop();
+
+        if (!result.valid) {
+            throw new Error(
+                result.error ||
+                    "Invalid token or insufficient permissions. Please verify your token has 'Account Analytics: Read' permission.",
+            );
+        }
+    } catch (error) {
+        s.stop();
+        if (error instanceof Error) {
+            throw error;
+        }
+        throw new Error(
+            "Failed to validate token. Please check your internet connection.",
+        );
     }
 
     return cfApiToken;
 }
-
-
 
 export async function promptPasswordProtection(): Promise<boolean> {
     const enableAuth = await confirm({

--- a/packages/cli/src/lib/__tests__/cloudflare.test.ts
+++ b/packages/cli/src/lib/__tests__/cloudflare.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { CloudflareClient, validateCloudflareToken } from "../cloudflare.js";
+import { CloudflareClient } from "../cloudflare.js";
 import { ProcessOutput } from "zx";
 import path from "path";
 import { homedir } from "node:os";
@@ -250,7 +250,10 @@ Getting User settings...
 
             const result = await client.getAccounts();
             expect(result).toEqual([
-                { id: mockAccountId, name: `Account ${mockAccountId.slice(-6)}` },
+                {
+                    id: mockAccountId,
+                    name: `Account ${mockAccountId.slice(-6)}`,
+                },
             ]);
         });
 
@@ -287,7 +290,9 @@ Getting User settings...
                 };
             });
 
-            await expect(client.getAccounts()).rejects.toThrow("Command failed");
+            await expect(client.getAccounts()).rejects.toThrow(
+                "Command failed",
+            );
         });
     });
 
@@ -326,7 +331,7 @@ Getting User settings...
     });
 });
 
-describe("validateCloudflareToken", () => {
+describe("CloudflareClient.validateToken", () => {
     beforeEach(() => {
         vi.resetAllMocks();
     });
@@ -340,7 +345,7 @@ describe("validateCloudflareToken", () => {
             }),
         });
 
-        const result = await validateCloudflareToken("valid-token");
+        const result = await CloudflareClient.validateToken("valid-token");
         expect(result.valid).toBe(true);
         expect(result.error).toBeUndefined();
     });
@@ -352,7 +357,7 @@ describe("validateCloudflareToken", () => {
             statusText: "Unauthorized",
         });
 
-        const result = await validateCloudflareToken("invalid-token");
+        const result = await CloudflareClient.validateToken("invalid-token");
         expect(result.valid).toBe(false);
         expect(result.error).toBe("Invalid or expired token");
     });
@@ -364,7 +369,7 @@ describe("validateCloudflareToken", () => {
             statusText: "Forbidden",
         });
 
-        const result = await validateCloudflareToken(
+        const result = await CloudflareClient.validateToken(
             "insufficient-permissions",
         );
         expect(result.valid).toBe(false);
@@ -378,7 +383,7 @@ describe("validateCloudflareToken", () => {
             statusText: "Internal Server Error",
         });
 
-        const result = await validateCloudflareToken("any-token");
+        const result = await CloudflareClient.validateToken("any-token");
         expect(result.valid).toBe(false);
         expect(result.error).toBe("HTTP 500: Internal Server Error");
     });
@@ -392,7 +397,7 @@ describe("validateCloudflareToken", () => {
             }),
         });
 
-        const result = await validateCloudflareToken("failed-token");
+        const result = await CloudflareClient.validateToken("failed-token");
         expect(result.valid).toBe(false);
         expect(result.error).toBe("Authentication failed");
     });
@@ -406,7 +411,7 @@ describe("validateCloudflareToken", () => {
             }),
         });
 
-        const result = await validateCloudflareToken("inactive-token");
+        const result = await CloudflareClient.validateToken("inactive-token");
         expect(result.valid).toBe(false);
         expect(result.error).toBe("Token is not active");
     });
@@ -414,7 +419,7 @@ describe("validateCloudflareToken", () => {
     it("should handle network errors", async () => {
         (global.fetch as any).mockRejectedValueOnce(new Error("Network error"));
 
-        const result = await validateCloudflareToken("any-token");
+        const result = await CloudflareClient.validateToken("any-token");
         expect(result.valid).toBe(false);
         expect(result.error).toBe("Network error");
     });
@@ -422,7 +427,7 @@ describe("validateCloudflareToken", () => {
     it("should handle unknown errors", async () => {
         (global.fetch as any).mockRejectedValueOnce("Unknown error");
 
-        const result = await validateCloudflareToken("any-token");
+        const result = await CloudflareClient.validateToken("any-token");
         expect(result.valid).toBe(false);
         expect(result.error).toBe("Network error during validation");
     });
@@ -436,7 +441,7 @@ describe("validateCloudflareToken", () => {
             }),
         });
 
-        await validateCloudflareToken("test-token");
+        await CloudflareClient.validateToken("test-token");
 
         expect(global.fetch).toHaveBeenCalledWith(
             "https://api.cloudflare.com/client/v4/user/tokens/verify",

--- a/packages/cli/src/lib/cloudflare.ts
+++ b/packages/cli/src/lib/cloudflare.ts
@@ -155,3 +155,67 @@ export class CloudflareClient {
         }
     }
 }
+
+interface TokenValidationResponse {
+    success: boolean;
+    result?: {
+        id: string;
+        status: string;
+    };
+    errors?: Array<{ code: number; message: string }>;
+}
+
+export async function validateCloudflareToken(
+    token: string,
+): Promise<{ valid: boolean; error?: string }> {
+    try {
+        const response = await fetch(
+            "https://api.cloudflare.com/client/v4/user/tokens/verify",
+            {
+                method: "GET",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+            },
+        );
+
+        if (!response.ok) {
+            if (response.status === 401) {
+                return { valid: false, error: "Invalid or expired token" };
+            }
+            if (response.status === 403) {
+                return {
+                    valid: false,
+                    error: "Token lacks required permissions",
+                };
+            }
+            return {
+                valid: false,
+                error: `HTTP ${response.status}: ${response.statusText}`,
+            };
+        }
+
+        const data: TokenValidationResponse = await response.json();
+
+        if (!data.success) {
+            const errorMessage =
+                data.errors?.[0]?.message || "Token validation failed";
+            return { valid: false, error: errorMessage };
+        }
+
+        if (data.result?.status !== "active") {
+            return { valid: false, error: "Token is not active" };
+        }
+
+        return { valid: true };
+    } catch (error) {
+        return {
+            valid: false,
+            error:
+                error instanceof Error
+                    ? error.message
+                    : "Network error during validation",
+        };
+    }
+}


### PR DESCRIPTION
Closes #195 

## Overview
Adds api bearer token verification during install using cloudflares verify endpoint. 

> [!NOTE]
> In order to verify a tokens permissions, the token entered needs to be created as a user level token with `API Tokens: Read`. IMO this complicates the setup process and limits what tokens can be used to deploy Counterscale, so we only do basic validation during install.

## Changes
### @counterscale/cli
- Adds an async static method, `verifyToken`, to `CloudflareClient`
- When then use this method inside the install command