### PR TITLE
Use fixed intervals instead of NOW() in queries

### DIFF
--- a/packages/server/app/analytics/__tests__/query.test.ts
+++ b/packages/server/app/analytics/__tests__/query.test.ts
@@ -630,27 +630,30 @@ describe("intervalToSql", () => {
     // test intervalToSql
     test("should return the proper sql interval for 1d, 30d, 90d, etc (days)", () => {
         expect(intervalToSql("1d")).toStrictEqual({
-            startIntervalSql: "NOW() - INTERVAL '1' DAY",
-            endIntervalSql: "NOW()",
+            startIntervalSql:
+                "toStartOfInterval(NOW() - INTERVAL '1' DAY, INTERVAL '5' MINUTE)",
+            endIntervalSql: "toStartOfInterval(NOW(), INTERVAL '5' MINUTE)",
         });
         expect(intervalToSql("30d")).toStrictEqual({
-            startIntervalSql: "NOW() - INTERVAL '30' DAY",
-            endIntervalSql: "NOW()",
+            startIntervalSql:
+                "toStartOfInterval(NOW() - INTERVAL '30' DAY, INTERVAL '5' MINUTE)",
+            endIntervalSql: "toStartOfInterval(NOW(), INTERVAL '5' MINUTE)",
         });
         expect(intervalToSql("90d")).toStrictEqual({
-            startIntervalSql: "NOW() - INTERVAL '90' DAY",
-            endIntervalSql: "NOW()",
+            startIntervalSql:
+                "toStartOfInterval(NOW() - INTERVAL '90' DAY, INTERVAL '5' MINUTE)",
+            endIntervalSql: "toStartOfInterval(NOW(), INTERVAL '5' MINUTE)",
         });
     });
 
     test("should return the proper tz-adjusted sql interval for 'today'", () => {
         expect(intervalToSql("today", "America/New_York")).toStrictEqual({
             startIntervalSql: "toDateTime('2024-04-29 04:00:00')",
-            endIntervalSql: "NOW()",
+            endIntervalSql: "toStartOfInterval(NOW(), INTERVAL '5' MINUTE)",
         });
         expect(intervalToSql("today", "America/Los_Angeles")).toStrictEqual({
             startIntervalSql: "toDateTime('2024-04-29 07:00:00')",
-            endIntervalSql: "NOW()",
+            endIntervalSql: "toStartOfInterval(NOW(), INTERVAL '5' MINUTE)",
         });
     });
 
@@ -665,5 +668,17 @@ describe("intervalToSql", () => {
                 endIntervalSql: "toDateTime('2024-04-29 07:00:00')",
             },
         );
+    });
+
+    test("should support custom bucket intervals", () => {
+        expect(intervalToSql("1d", undefined, 10)).toStrictEqual({
+            startIntervalSql:
+                "toStartOfInterval(NOW() - INTERVAL '1' DAY, INTERVAL '10' MINUTE)",
+            endIntervalSql: "toStartOfInterval(NOW(), INTERVAL '10' MINUTE)",
+        });
+        expect(intervalToSql("today", "America/New_York", 15)).toStrictEqual({
+            startIntervalSql: "toDateTime('2024-04-29 04:00:00')",
+            endIntervalSql: "toStartOfInterval(NOW(), INTERVAL '15' MINUTE)",
+        });
     });
 });

--- a/packages/server/app/analytics/query.ts
+++ b/packages/server/app/analytics/query.ts
@@ -46,14 +46,18 @@ function accumulateCountsFromRowResult(
     counts.views += Number(row.count);
 }
 
-export function intervalToSql(interval: string, tz?: string) {
+export function intervalToSql(
+    interval: string,
+    tz?: string,
+    bucketIntervalMinutes: number = 5,
+) {
     let startIntervalSql = "";
     let endIntervalSql = "";
     switch (interval) {
         case "today":
             // example: toDateTime('2024-01-07 00:00:00', 'America/New_York')
             startIntervalSql = `toDateTime('${dayjs().tz(tz).startOf("day").utc().format("YYYY-MM-DD HH:mm:ss")}')`;
-            endIntervalSql = "NOW()";
+            endIntervalSql = `toStartOfInterval(NOW(), INTERVAL '${bucketIntervalMinutes}' MINUTE)`;
             break;
         case "yesterday":
             startIntervalSql = `toDateTime('${dayjs().tz(tz).startOf("day").utc().subtract(1, "day").format("YYYY-MM-DD HH:mm:ss")}')`;
@@ -63,12 +67,12 @@ export function intervalToSql(interval: string, tz?: string) {
         case "7d":
         case "30d":
         case "90d":
-            startIntervalSql = `NOW() - INTERVAL '${interval.split("d")[0]}' DAY`;
-            endIntervalSql = "NOW()";
+            startIntervalSql = `toStartOfInterval(NOW() - INTERVAL '${interval.split("d")[0]}' DAY, INTERVAL '${bucketIntervalMinutes}' MINUTE)`;
+            endIntervalSql = `toStartOfInterval(NOW(), INTERVAL '${bucketIntervalMinutes}' MINUTE)`;
             break;
         default:
-            startIntervalSql = `NOW() - INTERVAL '1' DAY`;
-            endIntervalSql = "NOW()";
+            startIntervalSql = `toStartOfInterval(NOW() - INTERVAL '1' DAY, INTERVAL '${bucketIntervalMinutes}' MINUTE)`;
+            endIntervalSql = `toStartOfInterval(NOW(), INTERVAL '${bucketIntervalMinutes}' MINUTE)`;
     }
     return { startIntervalSql, endIntervalSql };
 }


### PR DESCRIPTION
Closes #65 

Queries are now using fixed intervals (5 minutes) which is already causing the dashboard to load faster. As called out in the issue, we're using `toStartOfInterval` to achieve this