### PR TITLE
fix: avoid tableFromJSON codegen for Cloudflare Workers compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ There is only one "database": the Cloudflare Analytics Engine dataset, which is 
 Right now there is no local "test" database. This means in local development:
 
 - Writes will no-op (no hits will be recorded)
-- Reads will be read from the production Analaytics Engine dataset (local development shows production data)
+- Reads will be read from the production Analytics Engine dataset (local development shows production data)
 
 ### Sampling
 

--- a/packages/server/workers/lib/__tests__/arrow.test.ts
+++ b/packages/server/workers/lib/__tests__/arrow.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "vitest";
+import { tableFromIPC, tableToIPC } from "apache-arrow";
+
+import { recordsToTable } from "../arrow";
+
+describe("recordsToTable", () => {
+    test("round-trips mixed string/number columns through Arrow IPC", () => {
+        const records = [
+            {
+                date: "2026-05-11",
+                siteId: "site-a",
+                views: 12,
+                visitors: 7,
+                bounces: 3,
+                path: "/",
+                country: "US",
+            },
+            {
+                date: "2026-05-11",
+                siteId: "site-a",
+                views: 5,
+                visitors: 4,
+                bounces: 0,
+                path: "/docs",
+                country: "TW",
+            },
+        ];
+
+        const table = recordsToTable(records);
+        const buf = new Uint8Array(tableToIPC(table, "file"));
+        const decoded = tableFromIPC(buf);
+
+        expect(decoded.numRows).toBe(2);
+        expect(decoded.schema.fields.map((f) => f.name)).toEqual([
+            "date",
+            "siteId",
+            "views",
+            "visitors",
+            "bounces",
+            "path",
+            "country",
+        ]);
+
+        const rows = decoded.toArray().map((r: unknown) => {
+            const row = r as Record<string, unknown>;
+            return {
+                date: String(row.date),
+                siteId: String(row.siteId),
+                views: Number(row.views),
+                visitors: Number(row.visitors),
+                bounces: Number(row.bounces),
+                path: String(row.path),
+                country: String(row.country),
+            };
+        });
+        expect(rows).toEqual(records);
+    });
+
+    test("handles null/undefined values without crashing", () => {
+        const records = [
+            { a: "x", b: 1 },
+            { a: null, b: null },
+            { a: undefined, b: undefined },
+        ];
+        const table = recordsToTable(records);
+        const buf = new Uint8Array(tableToIPC(table, "file"));
+        const decoded = tableFromIPC(buf);
+        expect(decoded.numRows).toBe(3);
+    });
+
+    test("returns empty table for empty input", () => {
+        const table = recordsToTable([]);
+        expect(table.numRows).toBe(0);
+    });
+
+    test("does not invoke `new Function()` (CF Workers codegen ban)", () => {
+        // Cloudflare Workers' runtime forbids `new Function(...)` and `eval`.
+        // apache-arrow's Builder path (used by tableFromJSON / vectorFromArray)
+        // triggers `new Function()` for validity-check codegen — this is the
+        // exact regression we are guarding against.
+        const realFunction = globalThis.Function;
+        let callCount = 0;
+        const FunctionProxy = new Proxy(realFunction, {
+            construct(target, args) {
+                callCount++;
+                return Reflect.construct(target, args);
+            },
+            apply(target, thisArg, args) {
+                callCount++;
+                return Reflect.apply(target, thisArg, args);
+            },
+        });
+
+        const records = [
+            { date: "2026-05-11", siteId: "s", views: 1, path: "/" },
+        ];
+
+        try {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (globalThis as any).Function = FunctionProxy;
+            const table = recordsToTable(records);
+            tableToIPC(table, "file");
+        } finally {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (globalThis as any).Function = realFunction;
+        }
+
+        expect(callCount).toBe(0);
+    });
+});

--- a/packages/server/workers/lib/__tests__/arrow.test.ts
+++ b/packages/server/workers/lib/__tests__/arrow.test.ts
@@ -56,7 +56,7 @@ describe("recordsToTable", () => {
         expect(rows).toEqual(records);
     });
 
-    test("handles null/undefined values without crashing", () => {
+    test("round-trips null/undefined values as null", () => {
         const records = [
             { a: "x", b: 1 },
             { a: null, b: null },
@@ -65,7 +65,31 @@ describe("recordsToTable", () => {
         const table = recordsToTable(records);
         const buf = new Uint8Array(tableToIPC(table, "file"));
         const decoded = tableFromIPC(buf);
-        expect(decoded.numRows).toBe(3);
+        const rows = decoded.toArray().map((row: unknown) => {
+            const values = row as Record<string, unknown>;
+            return { a: values.a, b: values.b };
+        });
+
+        expect(rows).toEqual([
+            { a: "x", b: 1 },
+            { a: null, b: null },
+            { a: null, b: null },
+        ]);
+    });
+
+    test("only allocates validity bitmaps for columns with nulls", () => {
+        const table = recordsToTable([
+            { nullable: null, complete: "x" },
+            { nullable: "value", complete: "y" },
+        ]);
+        const batch = table.batches[0];
+        const nullable = batch.getChild("nullable")?.data[0];
+        const complete = batch.getChild("complete")?.data[0];
+
+        expect(nullable?.nullCount).toBe(1);
+        expect(nullable?.nullBitmap.byteLength).toBe(8);
+        expect(complete?.nullCount).toBe(0);
+        expect(complete?.nullBitmap.byteLength).toBe(0);
     });
 
     test("returns empty table for empty input", () => {

--- a/packages/server/workers/lib/arrow.ts
+++ b/packages/server/workers/lib/arrow.ts
@@ -1,7 +1,94 @@
 import { AnalyticsEngineAPI } from "../../app/analytics/query";
 import { ColumnMappings } from "../../app/analytics/schema";
-import { tableFromJSON, tableToIPC } from "apache-arrow";
+import {
+    type Data,
+    Float64,
+    RecordBatch,
+    Schema,
+    Table,
+    Utf8,
+    makeData,
+    tableToIPC,
+} from "apache-arrow";
 import dayjs from "dayjs";
+
+type RecordValue = string | number | null | undefined;
+type Record = { [key: string]: RecordValue };
+
+// Build a Utf8 Data buffer directly from an array of strings.
+// Bypasses apache-arrow's Builder path, which uses `new Function()` for
+// validity-checking codegen and is forbidden by the Cloudflare Workers
+// runtime ("Code generation from strings disallowed for this context").
+function buildUtf8Data(values: (string | null | undefined)[]): Data<Utf8> {
+    const encoder = new TextEncoder();
+    const encoded: Uint8Array[] = new Array(values.length);
+    let totalBytes = 0;
+    for (let i = 0; i < values.length; i++) {
+        const v = values[i];
+        const bytes = v == null ? new Uint8Array(0) : encoder.encode(String(v));
+        encoded[i] = bytes;
+        totalBytes += bytes.length;
+    }
+    const valueOffsets = new Int32Array(values.length + 1);
+    const data = new Uint8Array(totalBytes);
+    let pos = 0;
+    for (let i = 0; i < values.length; i++) {
+        valueOffsets[i] = pos;
+        data.set(encoded[i], pos);
+        pos += encoded[i].length;
+    }
+    valueOffsets[values.length] = pos;
+    return makeData({
+        type: new Utf8(),
+        length: values.length,
+        nullCount: 0,
+        valueOffsets,
+        data,
+    });
+}
+
+function buildFloat64Data(values: (number | null | undefined)[]): Data<Float64> {
+    const buf = new Float64Array(values.length);
+    for (let i = 0; i < values.length; i++) {
+        buf[i] = values[i] ?? 0;
+    }
+    return makeData({
+        type: new Float64(),
+        length: values.length,
+        nullCount: 0,
+        data: buf,
+    });
+}
+
+// Convert an array of homogeneous records to an Arrow Table without invoking
+// the Builder/`new Function()` codegen path. Column type is inferred from the
+// first non-null sample per column: `number` → Float64, otherwise → Utf8.
+export function recordsToTable(records: Record[]): Table {
+    if (records.length === 0) {
+        return new Table(new Schema([]));
+    }
+    const columnNames = Object.keys(records[0]);
+    const children: { [name: string]: Data } = {};
+    for (const name of columnNames) {
+        let sample: RecordValue = undefined;
+        for (const r of records) {
+            const v = r[name];
+            if (v != null) {
+                sample = v;
+                break;
+            }
+        }
+        const values = records.map((r) => r[name]);
+        if (typeof sample === "number") {
+            children[name] = buildFloat64Data(values as (number | null)[]);
+        } else {
+            children[name] = buildUtf8Data(
+                values.map((v) => (v == null ? null : String(v))),
+            );
+        }
+    }
+    return new Table(new RecordBatch(children));
+}
 
 export async function extractAsArrow(
     { accountId, bearerToken }: { accountId: string; bearerToken: string },
@@ -27,10 +114,10 @@ export async function extractAsArrow(
     );
 
     // Convert Map to array of records for Arrow table creation
-    const records: any[] = [];
+    const records: Record[] = [];
     data.forEach((counts, key) => {
         const [date, siteId, ...columnValues] = key;
-        const record: any = {
+        const record: Record = {
             date,
             siteId,
             views: counts.views,
@@ -46,8 +133,8 @@ export async function extractAsArrow(
         records.push(record);
     });
 
-    // Create Arrow table from JSON records
-    const table = tableFromJSON(records);
+    // Build Arrow table without invoking codegen-based builders.
+    const table = recordsToTable(records);
 
     // Convert to Arrow IPC buffer
     const arrowBuffer = new Uint8Array(tableToIPC(table, "file"));

--- a/packages/server/workers/lib/arrow.ts
+++ b/packages/server/workers/lib/arrow.ts
@@ -15,6 +15,29 @@ import dayjs from "dayjs";
 type RecordValue = string | number | null | undefined;
 type Record = { [key: string]: RecordValue };
 
+function buildValidityBitmap(values: RecordValue[]): {
+    nullCount: number;
+    nullBitmap?: Uint8Array;
+} {
+    let nullCount = 0;
+    for (const value of values) {
+        if (value == null) {
+            nullCount++;
+        }
+    }
+    if (nullCount === 0) {
+        return { nullCount };
+    }
+
+    const nullBitmap = new Uint8Array(Math.ceil(values.length / 64) * 8);
+    for (let i = 0; i < values.length; i++) {
+        if (values[i] != null) {
+            nullBitmap[i >> 3] |= 1 << (i & 7);
+        }
+    }
+    return { nullCount, nullBitmap };
+}
+
 // Build a Utf8 Data buffer directly from an array of strings.
 // Bypasses apache-arrow's Builder path, which uses `new Function()` for
 // validity-checking codegen and is forbidden by the Cloudflare Workers
@@ -38,10 +61,12 @@ function buildUtf8Data(values: (string | null | undefined)[]): Data<Utf8> {
         pos += encoded[i].length;
     }
     valueOffsets[values.length] = pos;
+    const { nullCount, nullBitmap } = buildValidityBitmap(values);
     return makeData({
         type: new Utf8(),
         length: values.length,
-        nullCount: 0,
+        nullCount,
+        nullBitmap,
         valueOffsets,
         data,
     });
@@ -52,17 +77,21 @@ function buildFloat64Data(values: (number | null | undefined)[]): Data<Float64> 
     for (let i = 0; i < values.length; i++) {
         buf[i] = values[i] ?? 0;
     }
+    const { nullCount, nullBitmap } = buildValidityBitmap(values);
     return makeData({
         type: new Float64(),
         length: values.length,
-        nullCount: 0,
+        nullCount,
+        nullBitmap,
         data: buf,
     });
 }
 
-// Convert an array of homogeneous records to an Arrow Table without invoking
-// the Builder/`new Function()` codegen path. Column type is inferred from the
-// first non-null sample per column: `number` → Float64, otherwise → Utf8.
+/**
+ * Converts homogeneous records to an Arrow Table without Builder codegen and
+ * preserves null or undefined values as Arrow nulls. Column type is inferred
+ * from the first non-null sample: `number` becomes Float64, otherwise Utf8.
+ */
 export function recordsToTable(records: Record[]): Table {
     if (records.length === 0) {
         return new Table(new Schema([]));


### PR DESCRIPTION
## Problem

The daily-rollup scheduled handler (`extractAsArrow` in
`packages/server/workers/lib/arrow.ts`) cannot succeed on Cloudflare
Workers as currently written.

`apache-arrow`'s `tableFromJSON()` internally walks records and
triggers `vectorFromArray` → `makeBuilder` → `new StructBuilder` →
`new Builder` → `createIsValidFunction`, which calls
`new Function(...)` to generate validity-check code at runtime. The
Cloudflare Workers runtime forbids this:

```
EvalError: Code generation from strings disallowed for this context
    at new Function (<anonymous>)
    at createIsValidFunction
    at new Builder
    at new StructBuilder
    at makeBuilder
    at vectorFromArray
    at tableFromJSON
    at extractAsArrow
```

I observed this on a real counterscale deployment with CF Workers
`compatibility_date = "2025-08-08"`. The cron has thrown on every fire
since the worker was deployed; no Arrow file has ever been written to
the daily-rollups R2 bucket.

## Fix

Replace `tableFromJSON(records)` with a small `recordsToTable` helper
that pivots records to columnar form and builds `Utf8` / `Float64`
Arrow `Data` directly via `makeData`, then assembles them into a
`RecordBatch`. This bypasses the Builder/codegen path entirely.

Column types are inferred per column from the first non-null sample
(`number` → Float64, otherwise → Utf8). This preserves the same column
shape `tableFromJSON` was producing for this consumer — the records
written here only ever have string and number fields.

Public API of `extractAsArrow` is unchanged (same return shape, same
filename pattern, same R2 write).

## Tests

Adds `workers/lib/__tests__/arrow.test.ts`:

- Round-trips a mixed string/number record set through
  `tableToIPC` / `tableFromIPC` and asserts values match.
- Handles `null` / `undefined` values.
- Returns an empty Table for empty input.
- Proxies `globalThis.Function` and asserts no `new Function(...)`
  call happens during table construction or IPC serialization — a
  unit-level guarantee that the Workers runtime restriction is
  satisfied.

## Notes

Happy to adjust style/structure to match the project's conventions.
The change is small and self-contained to `workers/lib/arrow.ts` plus
the new unit test.