### PR TITLE
docs: clarify tracking code loading methods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ NOTE: _If this is your first time deploying Counterscale, it may take take a few
 
 ### Start Recording Web Traffic from Your Website(s)
 
-You can load the tracking code using one of two methods:
+You can load the tracking code using one of the following methods:
 
 #### 1. Script Loader (CDN)
 


### PR DESCRIPTION
## Overview

Update the README wording for tracking code integration methods.

The README currently states that the tracking code can be loaded using "one of **two** methods", while **three** methods are actually documented below. To better reflect the available options and avoid future updates if additional integration methods are added, this change replaces the wording with "one of the following methods".

## Changes by Package

### @counterscale/cli

No changes.

### @counterscale/server

No changes.

### @counterscale/tracker

No changes.

### Other Changes

* Updated the README to replace "one of two methods" with "one of the following methods" to accurately reflect the documented options and improve future maintainability.

## Additional Notes

Documentation-only change. No functional changes.
