### PR TITLE
Fix UTM tracking when canonical link present

### DIFF
--- a/packages/tracker/integration/04_utmTracking/canonical.html
+++ b/packages/tracker/integration/04_utmTracking/canonical.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+    <head>
+        <title>04 UTM Tracking - Canonical URL</title>
+        <link rel="canonical" href="http://localhost:3004/04_utmTracking/canonical" />
+    </head>
+    <body>
+        <h1>UTM Tracking Test (canonical URL, no query string)</h1>
+
+        <script>
+            (function () {
+                window.counterscale = {
+                    q: [
+                        ["set", "siteId", "utm-test-site-id"],
+                        ["trackPageview"],
+                    ],
+                };
+            })();
+        </script>
+        <script
+            id="counterscale-script"
+            data-report-localhost
+            src="http://localhost:3004/tracker.js"
+        ></script>
+    </body>
+</html>

--- a/packages/tracker/integration/04_utmTracking/index.spec.ts
+++ b/packages/tracker/integration/04_utmTracking/index.spec.ts
@@ -101,6 +101,30 @@ test("handles mixed UTM and non-UTM parameters", async ({ page }) => {
     expect(params.has("uco")).toBe(false);
 });
 
+test("tracks UTM parameters when page has a canonical link without query string", async ({
+    page,
+}) => {
+    const collectRequestPromise = page.waitForRequest((request) =>
+        request.url().includes("/collect"),
+    );
+
+    await page.goto(
+        "http://localhost:3004/04_utmTracking/canonical.html?utm_source=google&utm_medium=cpc&utm_campaign=summer_sale",
+    );
+
+    const request = await collectRequestPromise;
+    expect(request).toBeTruthy();
+
+    const url = request.url();
+    const params = new URLSearchParams(url.split("?")[1]);
+
+    // The canonical URL has no query string, but the UTM params from the
+    // actual visited URL should still be tracked.
+    expect(params.get("us")).toBe("google"); // utm_source
+    expect(params.get("um")).toBe("cpc"); // utm_medium
+    expect(params.get("uc")).toBe("summer_sale"); // utm_campaign
+});
+
 test("tracks referrer from query parameters when document.referrer is missing", async ({
     page,
 }) => {

--- a/packages/tracker/src/lib/__tests__/track.spec.ts
+++ b/packages/tracker/src/lib/__tests__/track.spec.ts
@@ -291,6 +291,37 @@ describe("trackPageview", () => {
             );
         });
 
+        test("should take UTM parameters from location when a canonical link is present", async () => {
+            Object.defineProperty(window, "location", {
+                writable: true,
+                value: {
+                    pathname: "/test-path",
+                    search: "?utm_source=google&utm_medium=cpc",
+                    host: "example.com",
+                },
+            });
+            vi.spyOn(document, "querySelector").mockReturnValue({
+                href: "https://canonical.example/clean-path",
+            } as HTMLLinkElement);
+
+            const client = new Client({
+                siteId: "test-site",
+                reporterUrl: "https://example.com/collect",
+                autoTrackPageviews: false,
+            });
+
+            await trackPageview(client);
+
+            expect(makeRequestMock).toHaveBeenCalledWith(
+                "https://example.com/collect",
+                expect.objectContaining({
+                    p: "/clean-path",
+                    us: "google",
+                    um: "cpc",
+                }),
+            );
+        });
+
         test("should include only non-empty UTM parameters", async () => {
             // Mock location with partial UTM parameters
             Object.defineProperty(window, "location", {

--- a/packages/tracker/src/lib/track.ts
+++ b/packages/tracker/src/lib/track.ts
@@ -92,7 +92,9 @@ export async function trackPageview(
 
     const { hostname, path } = getHostnameAndPath(url, true);
     const referrer = getBrowserReferrer(hostname, opts.referrer || "");
-    const utmParams = getUtmParamsFromBrowserUrl(url);
+    const utmParams = getUtmParamsFromBrowserUrl(
+        opts.url || window.location.search,
+    );
 
     let hitType: string | undefined;
     try {

--- a/packages/tracker/src/lib/track.ts
+++ b/packages/tracker/src/lib/track.ts
@@ -4,7 +4,7 @@ import { makeRequest, checkCacheStatus } from "./request";
 import {
     getHostnameAndPath,
     getReferrer,
-    getUtmParamsFromBrowserUrl,
+    extractUtmParams,
     isLocalhostAddress,
 } from "../shared/utils";
 import { buildCollectRequestParams } from "../shared/request";
@@ -92,9 +92,10 @@ export async function trackPageview(
 
     const { hostname, path } = getHostnameAndPath(url, true);
     const referrer = getBrowserReferrer(hostname, opts.referrer || "");
-    const utmParams = getUtmParamsFromBrowserUrl(
-        opts.url || window.location.search,
-    );
+    // Canonical hrefs typically omit the query string, so UTM params must come
+    // from the URL the visitor actually landed on, not the canonical URL.
+    const utmSource = opts.url || window.location.search;
+    const utmParams = extractUtmParams(utmSource);
 
     let hitType: string | undefined;
     try {

--- a/packages/tracker/src/shared/__tests__/utils.test.ts
+++ b/packages/tracker/src/shared/__tests__/utils.test.ts
@@ -4,7 +4,7 @@ import {
     getHostnameAndPath,
     getReferrer,
     getUtmParamsFromUrl,
-    getUtmParamsFromBrowserUrl,
+    extractUtmParams,
     mergeUtmParams,
     queryParamStringify,
 } from "../utils";
@@ -220,11 +220,11 @@ describe("Shared Utils", () => {
         });
     });
 
-    describe("getUtmParamsFromBrowserUrl", () => {
+    describe("extractUtmParams", () => {
         it("should extract UTM parameters from path with query string", () => {
             const url = "/page?utm_source=google&utm_medium=cpc";
 
-            const result = getUtmParamsFromBrowserUrl(url);
+            const result = extractUtmParams(url);
 
             expect(result).toEqual({
                 us: "google",
@@ -232,10 +232,16 @@ describe("Shared Utils", () => {
             });
         });
 
+        it("should extract UTM parameters from a bare search string", () => {
+            const result = extractUtmParams("?utm_source=google");
+
+            expect(result).toEqual({ us: "google" });
+        });
+
         it("should return empty object for path without query string", () => {
             const url = "/page";
 
-            const result = getUtmParamsFromBrowserUrl(url);
+            const result = extractUtmParams(url);
 
             expect(result).toEqual({});
         });
@@ -244,7 +250,7 @@ describe("Shared Utils", () => {
             const url =
                 "/page?other=value&utm_source=facebook&another=param&utm_campaign=test";
 
-            const result = getUtmParamsFromBrowserUrl(url);
+            const result = extractUtmParams(url);
 
             expect(result).toEqual({
                 us: "facebook",
@@ -255,7 +261,7 @@ describe("Shared Utils", () => {
         it("should ignore empty UTM values", () => {
             const url = "/page?utm_source=&utm_medium=email&utm_campaign=";
 
-            const result = getUtmParamsFromBrowserUrl(url);
+            const result = extractUtmParams(url);
 
             expect(result).toEqual({
                 um: "email",

--- a/packages/tracker/src/shared/utils.ts
+++ b/packages/tracker/src/shared/utils.ts
@@ -64,10 +64,13 @@ export function getUtmParamsFromUrl(url: string): UtmParams {
     return utmParams;
 }
 
-export function getUtmParamsFromBrowserUrl(url: string): UtmParams {
+/**
+ * Extracts UTM parameters from either a full URL, a path with a query string,
+ * or a bare search string such as "?utm_source=google".
+ */
+export function extractUtmParams(url: string): UtmParams {
     const utmParams: UtmParams = {};
 
-    // Extract query string from path (browser-specific implementation)
     const queryStart = url.indexOf("?");
     if (queryStart === -1) return utmParams;
 


### PR DESCRIPTION
## Overview

Change `trackPageview` so that the UTM parameters are extracted from the actual browser URL instead of any `<link rel="canonical">` URL on the page. This way the UTM parameters in the link clicked by the user are not silently lost.

## Changes by Package

### @counterscale/tracker

`trackPageview` now uses `opts.url` (if present) or `window.location.url` as the source of UTM parameters, not any `<link rel="canonical">` URL on the page.


## Additional Notes

fixes #259
