### PR TITLE
Fix TableCard header hover overflow

### DIFF
--- a/packages/server/app/components/TableCard.tsx
+++ b/packages/server/app/components/TableCard.tsx
@@ -45,7 +45,7 @@ export default function TableCard({
     return (
         <Table>
             <TableHeader>
-                <TableRow className={`${gridCols}`}>
+                <TableRow className={`${gridCols} hover:bg-transparent`}>
                     {(columnHeaders || []).map((header: string, index) => (
                         <TableHead
                             key={header}

--- a/packages/server/app/components/__tests__/TableCard.test.tsx
+++ b/packages/server/app/components/__tests__/TableCard.test.tsx
@@ -29,6 +29,17 @@ describe("TableCard", () => {
         expect(screen.getByText("50")).toBeInTheDocument();
     });
 
+    test("disables hover styling for the header only", () => {
+        render(<TableCard {...defaultProps} />);
+
+        const headerRow = screen.getByText("Site").parentElement;
+        const bodyRow = screen.getByText("example.com").parentElement;
+
+        expect(headerRow).toHaveClass("hover:bg-transparent");
+        expect(headerRow).not.toHaveClass("hover:bg-muted/50");
+        expect(bodyRow).toHaveClass("hover:bg-muted/50");
+    });
+
     test("renders external link icon for URLs", () => {
         const propsWithUrls = {
             countByProperty: [


### PR DESCRIPTION
## Overview
- override the shared row hover background on the non-interactive `TableCard` header
- keep the existing hover background on data rows
- add a focused regression assertion for both header and body row classes

Closes #233.

## Test evidence
- `pnpm --filter @counterscale/server test -- app/components/__tests__/TableCard.test.tsx` (7 tests passed)
- `pnpm --filter @counterscale/server exec eslint app/components/TableCard.tsx app/components/__tests__/TableCard.test.tsx` (passed)
- `pnpm --filter @counterscale/server build` (passed)
- `pnpm --filter @counterscale/server typecheck` (passed after build generated the server output)
- `pnpm --filter @counterscale/server lint` (passed with 51 pre-existing warnings)

*This PR description was generated by Pi using OpenAI GPT-5.6 Sol*
