### PR TITLE
Fix fresh installs with current Wrangler worker-not-found error

### DIFF
--- a/packages/cli/src/lib/__tests__/cloudflare.test.ts
+++ b/packages/cli/src/lib/__tests__/cloudflare.test.ts
@@ -118,7 +118,7 @@ describe("CloudflareClient", () => {
             });
         });
 
-        it("should return empty object when worker not created", async () => {
+        it("should return empty object for the legacy worker-not-found error", async () => {
             vi.mocked($).mockImplementation(() => {
                 throw "other content \n[code: 10007] Worker not found";
             });
@@ -127,12 +127,22 @@ describe("CloudflareClient", () => {
             expect(result).toEqual({});
         });
 
-        it("should throw on other errors", async () => {
+        it("should return empty object for the current worker-not-found error", async () => {
             vi.mocked($).mockImplementation(() => {
-                throw "Unknown error";
+                throw '✘ [ERROR] Worker "counterscale" not found.';
             });
 
-            await expect(client.getCloudflareSecrets()).rejects.toThrow();
+            const result = await client.getCloudflareSecrets();
+            expect(result).toEqual({});
+        });
+
+        it("should propagate unrelated not-found errors", async () => {
+            const error = 'Resource "counterscale" not found.';
+            vi.mocked($).mockImplementation(() => {
+                throw error;
+            });
+
+            await expect(client.getCloudflareSecrets()).rejects.toBe(error);
         });
     });
 

--- a/packages/cli/src/lib/cloudflare.ts
+++ b/packages/cli/src/lib/cloudflare.ts
@@ -21,6 +21,17 @@ interface TokenValidationResponse {
     errors?: Array<{ code: number; message: string }>;
 }
 
+function isWorkerNotFoundError(error: unknown): boolean {
+    if (typeof error !== "string") {
+        return false;
+    }
+
+    return (
+        error.includes("[code: 10007]") ||
+        /\bWorker\s+"[^"\r\n]+"\s+not found\./i.test(error)
+    );
+}
+
 export class CloudflareClient {
     private configPath: string;
 
@@ -162,10 +173,7 @@ export class CloudflareClient {
             rawSecrets = await this.fetchCloudflareSecrets();
         } catch (err) {
             // worker not created yet
-            if (
-                typeof err === "string" &&
-                err.indexOf("[code: 10007]") !== -1
-            ) {
+            if (isWorkerNotFoundError(err)) {
                 return {};
             }
             throw err;


### PR DESCRIPTION
## Overview

- treat Wrangler's current `Worker "<name>" not found.` response as the expected fresh-install case
- preserve support for the legacy `[code: 10007]` response
- continue propagating unrelated errors

The current wording is matched with a deliberately bounded, case-insensitive pattern requiring the quoted Worker shape and terminal `not found.` text. This remains dependent on Wrangler's human-readable output, but avoids accepting arbitrary `not found` failures.

Closes #250.

## Test evidence

- `pnpm --filter @counterscale/cli test -- src/lib/__tests__/cloudflare.test.ts` — 28 passed
- `pnpm --filter @counterscale/cli test` — 103 passed
- `pnpm --filter @counterscale/cli typecheck` — passed
- `pnpm --filter @counterscale/cli build` — passed
- `pnpm --filter @counterscale/cli lint` — passed with existing warnings only

*This PR description was generated by Pi using OpenAI GPT-5.6 Sol*
