### PR TITLE
Fix collect endpoint for custom tracker filenames

### DIFF
--- a/packages/tracker/src/__tests__/tracker.spec.ts
+++ b/packages/tracker/src/__tests__/tracker.spec.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    init: vi.fn(),
+}));
+
+vi.mock("../index", () => ({
+    init: mocks.init,
+}));
+
+describe("tracker loader", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+        mocks.init.mockReset();
+        vi.resetModules();
+    });
+
+    test.each([
+        {
+            name: "default filename",
+            scriptUrl: "https://example.com/tracker.js",
+            reporterUrl: "https://example.com/collect",
+        },
+        {
+            name: "custom filename",
+            scriptUrl: "https://example.com/analytics.js",
+            reporterUrl: "https://example.com/collect",
+        },
+        {
+            name: "deployment subpath",
+            scriptUrl: "https://example.com/apps/counterscale/custom.js",
+            reporterUrl: "https://example.com/apps/counterscale/collect",
+        },
+        {
+            name: "query and hash components",
+            scriptUrl:
+                "https://example.com/apps/counterscale/custom.js?v=123#loader",
+            reporterUrl: "https://example.com/apps/counterscale/collect",
+        },
+    ])(
+        "derives the collect endpoint for $name",
+        async ({ scriptUrl, reporterUrl }) => {
+            document.body.innerHTML = `<script id="counterscale-script" data-site-id="test-site" src="${scriptUrl}"></script>`;
+
+            await import("../tracker");
+
+            expect(mocks.init).toHaveBeenCalledOnce();
+            expect(mocks.init).toHaveBeenCalledWith({
+                siteId: "test-site",
+                reportOnLocalhost: false,
+                reporterUrl,
+                autoTrackPageviews: true,
+            });
+        },
+    );
+});

--- a/packages/tracker/src/tracker.ts
+++ b/packages/tracker/src/tracker.ts
@@ -9,6 +9,14 @@ function findReporterScript() {
     return el;
 }
 
+function getReporterUrl(script: HTMLScriptElement | null): string | undefined {
+    if (!script?.src) {
+        return undefined;
+    }
+
+    return new URL("collect", script.src).href;
+}
+
 function getLegacySiteId(): string | undefined {
     // backwards compatibility layer with legacy API for setting
     // site id using inline script + global variables
@@ -33,7 +41,7 @@ function init() {
     const siteId = script?.getAttribute("data-site-id") || getLegacySiteId();
     const reportOnLocalhost = (script?.hasAttribute("data-report-localhost") && script?.getAttribute("data-report-localhost") !== "false") || false;
 
-    const reporterUrl = script?.src.replace("tracker.js", "collect");
+    const reporterUrl = getReporterUrl(script);
 
     if (!siteId || !reporterUrl) {
         return;


### PR DESCRIPTION
## Overview
- derive the `collect` endpoint as a sibling of the loaded tracker script with the URL API
- support custom tracker filenames while preserving deployment subpaths
- discard script query strings and fragments from the reporting endpoint
- add focused regression coverage for default/custom filenames, subpaths, and query/hash behavior

Closes #243.

## Test evidence
- `pnpm --filter @counterscale/tracker exec vitest run` — 10 files, 135 tests passed
- `pnpm --filter @counterscale/tracker typecheck` — passed
- `pnpm --filter @counterscale/tracker lint` — passed with 62 pre-existing warnings and no errors
- `pnpm --filter @counterscale/tracker build` — passed
- `git diff --check` — passed

## Residual risks
- None identified; endpoint construction relies on the browser-standard URL resolution used by supported runtimes.

*This PR description was generated by Pi using OpenAI GPT-5.6 Sol*