### PR TITLE
fix(cli): run bundled wrangler binary instead of npx

### DIFF
--- a/packages/cli/src/lib/__tests__/cloudflare.test.ts
+++ b/packages/cli/src/lib/__tests__/cloudflare.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { CloudflareClient } from "../cloudflare.js";
+import { CloudflareClient, getBundledWranglerBinPath } from "../cloudflare.js";
 import { ProcessOutput } from "zx";
 import path from "path";
 import { homedir } from "node:os";
+
+const nodeModuleState = vi.hoisted(() => ({ throwOnCreateRequire: false }));
 
 // Mock the entire zx module
 vi.mock("zx", async (importOriginal) => {
@@ -10,6 +12,19 @@ vi.mock("zx", async (importOriginal) => {
     return {
         ...actual,
         $: vi.fn(),
+    };
+});
+
+vi.mock("node:module", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("node:module")>();
+    return {
+        ...actual,
+        createRequire: vi.fn((...args) => {
+            if (nodeModuleState.throwOnCreateRequire) {
+                throw new Error("Simulated resolution failure");
+            }
+            return actual.createRequire(...args);
+        }),
     };
 });
 
@@ -25,6 +40,7 @@ describe("CloudflareClient", () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        nodeModuleState.throwOnCreateRequire = false;
         client = new CloudflareClient(mockConfigPath);
     });
 
@@ -42,6 +58,76 @@ describe("CloudflareClient", () => {
 
         it("should use provided config path", () => {
             expect(client["configPath"]).toBe(mockConfigPath);
+        });
+    });
+
+    describe("wrangler binary resolution", () => {
+        const mockAccountId = "1234567890abcdef1234567890abcdef";
+
+        // captured[i] holds the interpolated substitution values of the i-th
+        // `$` invocation. Templates like `${argv} secret list --config ${path}`
+        // yield multiple substitutions, so argv is itself a nested array.
+        function captureSubs(): unknown[][] {
+            const captured: unknown[][] = [];
+            vi.mocked($).mockImplementation(((...args: unknown[]) => {
+                const [strings, ...subs] = args;
+                if (!Array.isArray(strings)) {
+                    return ((
+                        templateStrings: TemplateStringsArray,
+                        ...subs: unknown[]
+                    ) => {
+                        captured.push(subs);
+                        return {
+                            stdout: `random content ${mockAccountId} \nmore random content`,
+                            stderr: "",
+                            exitCode: 0,
+                        };
+                    }) as any;
+                }
+                captured.push(subs);
+                return {
+                    stdout: JSON.stringify([]),
+                    stderr: "",
+                    exitCode: 0,
+                } as any;
+            }) as any);
+            return captured;
+        }
+
+        it("should resolve the wrangler binary bundled with the CLI", () => {
+            const binPath = getBundledWranglerBinPath();
+            expect(binPath).toMatch(/[\\/]bin[\\/]wrangler\.js$/);
+            expect(binPath).toContain("node_modules");
+        });
+
+        it("should spawn the bundled wrangler binary for whoami", async () => {
+            const captured = captureSubs();
+
+            await client.getAccountId();
+
+            expect(captured[0]).toEqual([
+                ["node", getBundledWranglerBinPath()],
+            ]);
+        });
+
+        it("should spawn the bundled wrangler binary for secret list", async () => {
+            const captured = captureSubs();
+
+            await client.getCloudflareSecrets();
+
+            expect(captured[0]).toEqual([
+                ["node", getBundledWranglerBinPath()],
+                mockConfigPath,
+            ]);
+        });
+
+        it("should fall back to npx wrangler when the bundled binary cannot be resolved", async () => {
+            nodeModuleState.throwOnCreateRequire = true;
+            const captured = captureSubs();
+
+            await client.getAccountId();
+
+            expect(captured[0]).toEqual([["npx", "wrangler"]]);
         });
     });
 

--- a/packages/cli/src/lib/__tests__/cloudflare.test.ts
+++ b/packages/cli/src/lib/__tests__/cloudflare.test.ts
@@ -1,10 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { CloudflareClient, getBundledWranglerBinPath } from "../cloudflare.js";
+import {
+    CloudflareClient,
+    getBundledWranglerBinPath,
+    resetWranglerBinPathCache,
+} from "../cloudflare.js";
 import { ProcessOutput } from "zx";
 import path from "path";
+import { createRequire } from "node:module";
 import { homedir } from "node:os";
 
-const nodeModuleState = vi.hoisted(() => ({ throwOnCreateRequire: false }));
+const nodeModuleState = vi.hoisted(() => ({
+    throwOnCreateRequire: false,
+    failExistsCheck: false,
+}));
 
 // Mock the entire zx module
 vi.mock("zx", async (importOriginal) => {
@@ -28,6 +36,19 @@ vi.mock("node:module", async (importOriginal) => {
     };
 });
 
+vi.mock("node:fs", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("node:fs")>();
+    return {
+        ...actual,
+        existsSync: vi.fn((...args) => {
+            if (nodeModuleState.failExistsCheck) {
+                return false;
+            }
+            return actual.existsSync(...args);
+        }),
+    };
+});
+
 // Import and spy on the mocked function
 const { $ } = await import("zx");
 
@@ -41,6 +62,8 @@ describe("CloudflareClient", () => {
     beforeEach(() => {
         vi.clearAllMocks();
         nodeModuleState.throwOnCreateRequire = false;
+        nodeModuleState.failExistsCheck = false;
+        resetWranglerBinPathCache();
         client = new CloudflareClient(mockConfigPath);
     });
 
@@ -100,6 +123,20 @@ describe("CloudflareClient", () => {
             expect(binPath).toContain("node_modules");
         });
 
+        it("should memoize the resolved binary path across calls", () => {
+            getBundledWranglerBinPath();
+
+            const createRequireSpy = vi.mocked(createRequire);
+            const callsAfterFirstResolution =
+                createRequireSpy.mock.calls.length;
+
+            getBundledWranglerBinPath();
+
+            expect(createRequireSpy.mock.calls.length).toBe(
+                callsAfterFirstResolution,
+            );
+        });
+
         it("should spawn the bundled wrangler binary for whoami", async () => {
             const captured = captureSubs();
 
@@ -121,13 +158,36 @@ describe("CloudflareClient", () => {
             ]);
         });
 
-        it("should fall back to npx wrangler when the bundled binary cannot be resolved", async () => {
+        it("should fall back to npx wrangler and warn when the bundled binary cannot be resolved", async () => {
             nodeModuleState.throwOnCreateRequire = true;
+            const warnSpy = vi
+                .spyOn(console, "warn")
+                .mockImplementation(() => {});
             const captured = captureSubs();
 
             await client.getAccountId();
 
             expect(captured[0]).toEqual([["npx", "wrangler"]]);
+            expect(warnSpy).toHaveBeenCalledWith(
+                "Failed to resolve bundled wrangler binary, falling back to npx:",
+                expect.anything(),
+            );
+            warnSpy.mockRestore();
+        });
+
+        it("should warn when the resolved binary path does not exist", () => {
+            nodeModuleState.failExistsCheck = true;
+            const warnSpy = vi
+                .spyOn(console, "warn")
+                .mockImplementation(() => {});
+
+            expect(getBundledWranglerBinPath()).toBeNull();
+            expect(warnSpy).toHaveBeenCalledWith(
+                expect.stringMatching(
+                    /Bundled wrangler binary not found at .*bin[\\/]wrangler\.js, falling back to npx/,
+                ),
+            );
+            warnSpy.mockRestore();
         });
     });
 

--- a/packages/cli/src/lib/cloudflare.ts
+++ b/packages/cli/src/lib/cloudflare.ts
@@ -1,10 +1,27 @@
 import { $, ProcessOutput } from "zx";
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
 import path from "path";
 import { homedir } from "node:os";
 
 interface SecretItem {
     name: string;
     type: string;
+}
+
+export function getBundledWranglerBinPath(): string | null {
+    try {
+        const require = createRequire(import.meta.url);
+        const packageJsonPath = require.resolve("wrangler/package.json");
+        const binPath = path.join(
+            path.dirname(packageJsonPath),
+            "bin",
+            "wrangler.js",
+        );
+        return existsSync(binPath) ? binPath : null;
+    } catch {
+        return null;
+    }
 }
 
 interface AccountInfo {
@@ -41,9 +58,16 @@ export class CloudflareClient {
             path.join(homedir(), ".counterscale", "wrangler.json");
     }
 
+    private wranglerArgv(): string[] {
+        const binPath = getBundledWranglerBinPath();
+        return binPath ? ["node", binPath] : ["npx", "wrangler"];
+    }
+
     async getAccountId(): Promise<string | null> {
         try {
-            const result = await $({ quiet: true })`npx wrangler whoami`;
+            const result = await $({
+                quiet: true,
+            })`${this.wranglerArgv()} whoami`;
             const match = result.stdout.match(/([0-9a-f]{32})/);
             return match ? match[0] : null;
         } catch (error) {
@@ -56,7 +80,9 @@ export class CloudflareClient {
 
     async getAccounts(): Promise<AccountInfo[]> {
         try {
-            const result = await $({ quiet: true })`npx wrangler whoami`;
+            const result = await $({
+                quiet: true,
+            })`${this.wranglerArgv()} whoami`;
             const accounts = this.parseAccountsFromTable(result.stdout);
             
             // If table parsing failed, fall back to single account
@@ -104,7 +130,7 @@ export class CloudflareClient {
     private async fetchCloudflareSecrets(): Promise<string> {
         try {
             const result =
-                await $`npx wrangler secret list --config ${this.configPath}`;
+                await $`${this.wranglerArgv()} secret list --config ${this.configPath}`;
             return result.stdout;
         } catch (error) {
             throw error instanceof ProcessOutput
@@ -192,7 +218,7 @@ export class CloudflareClient {
     ): Promise<boolean> {
         for (const [key, value] of Object.entries(secrets)) {
             try {
-                await $`echo ${value} | npx wrangler secret put ${key} --config ${this.configPath}`;
+                await $`echo ${value} | ${this.wranglerArgv()} secret put ${key} --config ${this.configPath}`;
             } catch {
                 return false;
             }
@@ -204,7 +230,7 @@ export class CloudflareClient {
         try {
             const p = $({
                 quiet: true,
-            })`npx wrangler deploy --config ${this.configPath} --var VERSION:${version}`;
+            })`${this.wranglerArgv()} deploy --config ${this.configPath} --var VERSION:${version}`;
 
             let output = "";
             for await (const text of p) {

--- a/packages/cli/src/lib/cloudflare.ts
+++ b/packages/cli/src/lib/cloudflare.ts
@@ -9,7 +9,13 @@ interface SecretItem {
     type: string;
 }
 
+let cachedWranglerBinPath: string | null | undefined;
+
 export function getBundledWranglerBinPath(): string | null {
+    if (cachedWranglerBinPath !== undefined) {
+        return cachedWranglerBinPath;
+    }
+
     try {
         const require = createRequire(import.meta.url);
         const packageJsonPath = require.resolve("wrangler/package.json");
@@ -18,10 +24,25 @@ export function getBundledWranglerBinPath(): string | null {
             "bin",
             "wrangler.js",
         );
-        return existsSync(binPath) ? binPath : null;
-    } catch {
-        return null;
+        cachedWranglerBinPath = existsSync(binPath) ? binPath : null;
+        if (!cachedWranglerBinPath) {
+            console.warn(
+                `Bundled wrangler binary not found at ${binPath}, falling back to npx`,
+            );
+        }
+    } catch (err) {
+        console.warn(
+            "Failed to resolve bundled wrangler binary, falling back to npx:",
+            err,
+        );
+        cachedWranglerBinPath = null;
     }
+
+    return cachedWranglerBinPath;
+}
+
+export function resetWranglerBinPathCache(): void {
+    cachedWranglerBinPath = undefined;
 }
 
 interface AccountInfo {
@@ -84,15 +105,20 @@ export class CloudflareClient {
                 quiet: true,
             })`${this.wranglerArgv()} whoami`;
             const accounts = this.parseAccountsFromTable(result.stdout);
-            
+
             // If table parsing failed, fall back to single account
             if (accounts.length === 0) {
                 const accountId = await this.getAccountId();
                 if (accountId) {
-                    return [{ id: accountId, name: `Account ${accountId.slice(-6)}` }];
+                    return [
+                        {
+                            id: accountId,
+                            name: `Account ${accountId.slice(-6)}`,
+                        },
+                    ];
                 }
             }
-            
+
             return accounts;
         } catch (error) {
             if (error instanceof ProcessOutput) {
@@ -104,26 +130,33 @@ export class CloudflareClient {
 
     private parseAccountsFromTable(output: string): AccountInfo[] {
         const accounts: AccountInfo[] = [];
-        const lines = output.split('\n');
-        
+        const lines = output.split("\n");
+
         for (const line of lines) {
             // Skip header and separator lines
-            if (!line.includes('│') || line.includes('Account Name') || line.includes('─')) {
+            if (
+                !line.includes("│") ||
+                line.includes("Account Name") ||
+                line.includes("─")
+            ) {
                 continue;
             }
-            
-            const parts = line.split('│').map(part => part.trim()).filter(Boolean);
-            
+
+            const parts = line
+                .split("│")
+                .map((part) => part.trim())
+                .filter(Boolean);
+
             if (parts.length >= 2) {
                 const [name, id] = parts;
-                
+
                 // Validate account ID format (32 hex characters)
                 if (/^[0-9a-f]{32}$/.test(id)) {
                     accounts.push({ id, name });
                 }
             }
         }
-        
+
         return accounts;
     }
 
@@ -173,7 +206,8 @@ export class CloudflareClient {
             const data: TokenValidationResponse = await response.json();
 
             if (!data.success) {
-                const errorMessage = data.errors?.[0]?.message || "Token validation failed";
+                const errorMessage =
+                    data.errors?.[0]?.message || "Token validation failed";
                 return { valid: false, error: errorMessage };
             }
 
@@ -252,4 +286,3 @@ export class CloudflareClient {
         }
     }
 }
-


### PR DESCRIPTION
Fixes #256

## Problem

Running `npx @counterscale/cli@latest install` fails with:

```
✘ [ERROR] Processing /var/folders/.../counterscale-XXXX/wrangler.json configuration:
    - "assets.bucket" is a required field.
```

## Root cause

The CLI spawned bare `npx wrangler` for every wrangler invocation (`whoami`, `secret list`, `secret put`, `deploy`). `npx` resolves wrangler from the **user's environment** — the npx cache entry keyed by the bare `wrangler` spec (which is never auto-upgraded once cached), `PATH`, or a parent `node_modules` — not the wrangler bundled with `@counterscale/cli`.

When that resolution lands on wrangler < 3.78.10, it misinterprets the modern `assets: { directory }` config in `packages/server/wrangler.json` as legacy Workers Sites config and throws exactly this error (documented in [Cloudflare's troubleshooting docs](https://developers.cloudflare.com/workers/static-assets/billing-and-limitations/#assetsbucket-is-a-required-field)).

Verified by running wrangler 3.60.0 against a CLI-staged config (reproduces the exact error), while the wrangler bundled with the CLI (4.x) parses the same config fine.

## Fix

- Add `getBundledWranglerBinPath()` which resolves `bin/wrangler.js` inside the CLI's own pinned `wrangler@^4.23.0` dependency (via `createRequire(...).resolve("wrangler/package.json")`, which wrangler's exports map allows)
- All spawn sites now run `node <bundled-bin>` via `wranglerArgv()`, falling back to the old `npx wrangler` behavior only if resolution fails
- The fallback is no longer silent: a `console.warn` explains which wrangler is being used if the bundled binary can't be resolved; the resolved path is memoized
- Note: wrangler 4.x requires Node 18+, so `node <bin>` implicitly raises the runtime floor — `@counterscale/cli` already requires Node >= 20 (engines field), so this is a non-issue in practice

## Testing

- Reproduced the reported error with a real old wrangler against a CLI-staged config; confirmed the bundled wrangler parses it successfully
- 6 new tests in `cloudflare.test.ts` covering bundled-binary resolution, memoization, the argv used by `whoami` / `secret list`, the npx fallback, and the resolution-failure warnings
- `@counterscale/cli`: 109/109 tests pass, typecheck clean

## Follow-up

- #267 — secrets are currently piped through `echo` into `wrangler secret put`; special characters (newlines, `$`, backticks) can be mangled. Worth switching to stdin piping without a shell pipeline.
