### PR TITLE
Fix bounce-rate chart percentage scaling

### DIFF
--- a/packages/server/app/components/TimeSeriesChart.tsx
+++ b/packages/server/app/components/TimeSeriesChart.tsx
@@ -162,7 +162,7 @@ export default function TimeSeriesChart({
                 <YAxis
                     yAxisId="bounceRate"
                     dataKey="bounceRate"
-                    domain={[0, 120]}
+                    domain={[0, 100]}
                     hide={true}
                 />
 

--- a/packages/server/app/components/__tests__/TimeSeriesChart.test.tsx
+++ b/packages/server/app/components/__tests__/TimeSeriesChart.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { render, screen, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import "vitest-dom/extend-expect";
+
+import TimeSeriesChart from "../TimeSeriesChart";
+
+vi.mock("recharts", () => ({
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+        <div>{children}</div>
+    ),
+    ComposedChart: ({ children }: { children: React.ReactNode }) => (
+        <div>{children}</div>
+    ),
+    CartesianGrid: () => null,
+    XAxis: () => null,
+    YAxis: ({
+        yAxisId,
+        domain,
+    }: {
+        yAxisId: string;
+        domain: [number, number];
+    }) => (
+        <div
+            data-testid={`y-axis-${yAxisId}`}
+            data-domain={JSON.stringify(domain)}
+        />
+    ),
+    Tooltip: () => null,
+    Area: () => null,
+    Line: () => null,
+}));
+
+describe("TimeSeriesChart", () => {
+    afterEach(() => {
+        cleanup();
+    });
+
+    test("scales bounce rate against a fixed 0–100% domain", () => {
+        render(
+            <TimeSeriesChart
+                intervalType="DAY"
+                data={[
+                    {
+                        date: "2025-01-01T00:00:00.000Z",
+                        views: 100,
+                        visitors: 75,
+                        bounceRate: 46,
+                    },
+                ]}
+            />,
+        );
+
+        expect(screen.getByTestId("y-axis-bounceRate")).toHaveAttribute(
+            "data-domain",
+            "[0,100]",
+        );
+    });
+});


### PR DESCRIPTION
## Summary

- use a conventional fixed 0–100% domain for the bounce-rate chart axis
- ensure a 46% bounce rate occupies 46% of the independent percentage axis
- add focused regression coverage for the bounce-rate domain
- leave tooltip content and ordering unchanged

## Before and after

![Before and after comparison of the bounce-rate chart scale](https://gist.githubusercontent.com/benvinegar/2ccc88b115ba5b90078ee46dfa17f93f/raw/cacde4fc95b6feaff1d3f868fc0a919d80d36ff2/bounce-rate-before-after.png)

These Chromium captures use the actual `TimeSeriesChart`, Recharts, and repository CSS. The capture waited for chart animation to complete and verified stable, complete SVG paths before taking each screenshot.

For the 46% point:

- **Before, 0–120% domain:** occupied 38.33% of plot height
- **After, 0–100% domain:** occupies exactly 46% of plot height

The 100% point now reaches the top of the percentage plot, as expected. [Full methodology, individual captures, geometry, checksums, and test output](https://gist.github.com/benvinegar/2ccc88b115ba5b90078ee46dfa17f93f).

## Validation

- focused `TimeSeriesChart` regression test: 1 passed
- server suite: 30 files, 175 tests passed
- build: passed
- typecheck: passed after generating build output
- lint: passed with existing warnings only
- `git diff --check`: passed
- independent code and evidence review: passed with no blockers

Fixes #128

*This PR description was generated by Pi using OpenAI GPT-5.6 Sol*
